### PR TITLE
Disable auto-save when moving

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,6 @@ const game = {
                     gameState.player.y = y;
                     this.logMessage(`You travel ${direction}.`);
                     this.renderAll();
-                    this.saveGame();
                 },
 
                 logMessage(message) {


### PR DESCRIPTION
## Summary
- stop `move()` from calling `saveGame()` so the game only saves on clicking the **Save** button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844c4aa8f38832fb9e94c9b1a84aa54