### PR TITLE
Improve town generation variety

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,15 +131,17 @@
 
         <div id="building-overlay"
              class="hidden fixed inset-0 bg-black/75 flex items-center justify-center z-50">
-          <div class="bg-gray-800 p-6 rounded-lg max-w-sm w-full text-gray-300">
-            <h3 id="building-overlay-name" class="text-xl text-amber-100 mb-2"></h3>
-            <img id="building-overlay-image" class="mx-auto mb-4" src="" alt="">
-            <div class="space-y-2">
-              <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Talk</button>
-              <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Shop</button>
-              <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Rest</button>
+          <div class="bg-gray-800 p-6 rounded-lg max-w-2xl w-full text-gray-300 md:grid md:grid-cols-2 md:gap-4">
+            <h3 id="building-overlay-name" class="text-2xl text-amber-100 mb-2 md:col-span-2"></h3>
+            <div class="flex flex-col items-center mb-4 md:mb-0">
+              <img id="building-overlay-image" class="mx-auto mb-4 w-32 h-32 object-cover rounded" src="" alt="">
+              <p id="building-overlay-desc" class="text-sm text-gray-400"></p>
             </div>
-            <button id="close-building" class="mt-4 bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1">Close</button>
+            <div class="flex flex-col">
+              <div id="building-actions" class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4"></div>
+              <div id="building-log" class="bg-black/20 p-2 rounded-md text-xs h-32 overflow-y-auto mb-4"></div>
+              <button id="close-building" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Close</button>
+            </div>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -132,7 +132,8 @@
         <div id="building-overlay"
              class="hidden fixed inset-0 bg-black/75 flex items-center justify-center z-50">
           <div class="bg-gray-800 p-6 rounded-lg max-w-sm w-full text-gray-300">
-            <h3 id="building-overlay-name" class="text-xl text-amber-100 mb-4"></h3>
+            <h3 id="building-overlay-name" class="text-xl text-amber-100 mb-2"></h3>
+            <img id="building-overlay-image" class="mx-auto mb-4" src="" alt="">
             <div class="space-y-2">
               <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Talk</button>
               <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Shop</button>

--- a/src/game.js
+++ b/src/game.js
@@ -337,7 +337,7 @@ const game = {
           gameState.townState.x = x;
           gameState.townState.y = y;
           if (tile && !tile.road && tile.name) {
-            openBuildingOverlay(tile.name);
+            openBuildingOverlay(tile);
           }
           const name = tile ? (tile.road ? 'Road' : tile.name) : 'Empty Lot';
           document.getElementById('building-name').textContent = name;
@@ -427,13 +427,20 @@ function moveTown(dir) {
   game.renderTownMap();
 }
 
-function openBuildingOverlay(name) {
-  document.getElementById('building-overlay-name').textContent = name;
+function openBuildingOverlay(tile) {
+  document.getElementById('building-overlay-name').textContent = tile.name;
+  const img = document.getElementById('building-overlay-image');
+  if (img) {
+    img.src = tile.image || '';
+    img.alt = tile.type || 'building';
+  }
   document.getElementById('building-overlay').classList.remove('hidden');
 }
 
 function closeBuildingOverlay() {
   document.getElementById('building-overlay').classList.add('hidden');
+  const img = document.getElementById('building-overlay-image');
+  if (img) img.src = '';
 }
 
 function openCompanion(index) {

--- a/src/game.js
+++ b/src/game.js
@@ -23,9 +23,13 @@ const gameState = {
   isApiCallInProgress: false,
   worldSeed,
   townState: { x: 0, y: 0 },
+  buildingLogs: {},
 };
 
 let currentTown = null;
+let currentBuilding = null;
+let currentTownCoords = null;
+let currentBuildingKey = null;
 
 const game = {
   init() {
@@ -47,6 +51,7 @@ const game = {
       companions: gameState.companions,
       worldSeed: gameState.worldSeed,
       log: gameState.log,
+      buildingLogs: gameState.buildingLogs,
     };
     localStorage.setItem('aralia-save', JSON.stringify(data));
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -67,6 +72,7 @@ const game = {
       if (Array.isArray(data.inventory)) gameState.inventory = data.inventory;
       if (Array.isArray(data.companions)) gameState.companions = data.companions;
       if (Array.isArray(data.log)) gameState.log = data.log;
+      if (data.buildingLogs && typeof data.buildingLogs === 'object') gameState.buildingLogs = data.buildingLogs;
       if (data.worldSeed) {
         gameState.worldSeed = data.worldSeed;
         world.noise = new SimplexNoise(data.worldSeed);
@@ -322,13 +328,21 @@ const game = {
     for (let y = 0; y < currentTown.height; y++) {
       for (let x = 0; x < currentTown.width; x++) {
         const cell = document.createElement('div');
-        cell.className = 'w-6 h-6 flex items-center justify-center border border-gray-600 text-xs cursor-pointer';
+        cell.className = 'w-6 h-6 flex items-center justify-center border border-gray-600 text-xs cursor-pointer overflow-hidden';
         const tile = currentTown.grid[y][x];
         if (tile && tile.road) {
           cell.textContent = '-';
           cell.classList.add('text-yellow-500');
         } else {
-          cell.textContent = tile ? tile.name[0] : '.';
+          if (tile) {
+            const img = document.createElement('img');
+            img.src = tile.image;
+            img.alt = tile.type;
+            img.className = 'w-full h-full object-cover';
+            cell.appendChild(img);
+          } else {
+            cell.textContent = '.';
+          }
         }
         if (gameState.townState.x === x && gameState.townState.y === y) {
           cell.classList.add('bg-amber-500/50');
@@ -392,6 +406,7 @@ function openTownMap() {
     return;
   }
   currentTown = getTown(location.x, location.y);
+  currentTownCoords = { x: location.x, y: location.y };
   gameState.townState = { x: 0, y: 0 };
   const overlay = document.getElementById('town-overlay');
   overlay.classList.remove('hidden');
@@ -410,6 +425,13 @@ function handleTownKey(e) {
   if (e.key === 'ArrowDown') moveTown('south');
   if (e.key === 'ArrowLeft') moveTown('west');
   if (e.key === 'ArrowRight') moveTown('east');
+  if (e.key === 'Escape') {
+    if (!document.getElementById('building-overlay').classList.contains('hidden')) {
+      closeBuildingOverlay();
+    } else {
+      closeTownMap();
+    }
+  }
 }
 
 function moveTown(dir) {
@@ -427,20 +449,92 @@ function moveTown(dir) {
   game.renderTownMap();
 }
 
-function openBuildingOverlay(tile) {
+async function openBuildingOverlay(tile) {
+  currentBuilding = tile;
+  currentBuildingKey = `${currentTownCoords?.x ?? 0},${currentTownCoords?.y ?? 0}-${tile.x},${tile.y}`;
   document.getElementById('building-overlay-name').textContent = tile.name;
   const img = document.getElementById('building-overlay-image');
   if (img) {
     img.src = tile.image || '';
     img.alt = tile.type || 'building';
   }
+  const descEl = document.getElementById('building-overlay-desc');
+  if (descEl) descEl.textContent = '';
   document.getElementById('building-overlay').classList.remove('hidden');
+  if (descEl) {
+    descEl.textContent = '...';
+    let prompt;
+    if (tile.descTemplate) {
+      prompt = tile.descTemplate.replace('{name}', tile.name).replace('{type}', tile.type);
+    } else {
+      prompt = `You are a DM. Describe ${tile.name}, a ${tile.type} in one sentence.`;
+    }
+    const text = await game.callGemini(prompt);
+    if (text) descEl.textContent = text; else descEl.textContent = '';
+  }
+
+  const logContainer = document.getElementById('building-log');
+  if (logContainer) {
+    logContainer.innerHTML = '';
+    (gameState.buildingLogs[currentBuildingKey] || []).slice().reverse().forEach((msg) => {
+      const p = document.createElement('p');
+      p.textContent = msg;
+      p.className = 'text-gray-400';
+      logContainer.appendChild(p);
+    });
+  }
+  await generateBuildingActions();
+}
+
+async function generateBuildingActions() {
+  const actionsContainer = document.getElementById('building-actions');
+  if (!actionsContainer || !currentBuilding) return;
+  actionsContainer.innerHTML = '<div class="sm:col-span-2 flex justify-center items-center"><span class="spinner"></span><p class="ml-2">Thinking...</p></div>';
+  const recent = (gameState.buildingLogs[currentBuildingKey] || []).slice(0, 3).join(' | ');
+  const prompt = `You are a DM for a fantasy RPG. The player is in ${currentBuilding.name}, a ${currentBuilding.type}. Recent events: ${recent}. Provide a comma-separated list of exactly 4 short actions (1-3 words each) they can take inside.`;
+  const actionsString = await game.callGemini(prompt);
+  actionsContainer.innerHTML = '';
+  if (actionsString) {
+    actionsString.split(',').map(a => a.trim()).slice(0,4).forEach((text) => {
+      if (!text) return;
+      const btn = document.createElement('button');
+      btn.textContent = text;
+      btn.className = 'bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 text-base w-full whitespace-normal';
+      btn.onclick = () => handleBuildingAction(text);
+      actionsContainer.appendChild(btn);
+    });
+  } else {
+    actionsContainer.innerHTML = '<p class="text-gray-500 sm:col-span-2">Could not get actions.</p>';
+  }
 }
 
 function closeBuildingOverlay() {
   document.getElementById('building-overlay').classList.add('hidden');
   const img = document.getElementById('building-overlay-image');
   if (img) img.src = '';
+  const descEl = document.getElementById('building-overlay-desc');
+  if (descEl) descEl.textContent = '';
+  currentBuilding = null;
+  currentBuildingKey = null;
+}
+
+async function handleBuildingAction(action) {
+  if (!currentBuilding) return;
+  const prompt = `You are a DM. The player chooses to ${action} at ${currentBuilding.name}, a ${currentBuilding.type}. Respond in one short sentence.`;
+  const text = await game.callGemini(prompt);
+  if (text) {
+    if (!gameState.buildingLogs[currentBuildingKey]) gameState.buildingLogs[currentBuildingKey] = [];
+    gameState.buildingLogs[currentBuildingKey].unshift(text);
+    if (gameState.buildingLogs[currentBuildingKey].length > 50) gameState.buildingLogs[currentBuildingKey].pop();
+    const logContainer = document.getElementById('building-log');
+    if (logContainer) {
+      const p = document.createElement('p');
+      p.textContent = text;
+      p.className = 'text-gray-400';
+      logContainer.prepend(p);
+    }
+  }
+  generateBuildingActions();
 }
 
 function openCompanion(index) {
@@ -482,5 +576,6 @@ export {
   closeTownMap,
   openBuildingOverlay,
   closeBuildingOverlay,
+  handleBuildingAction,
   moveTown,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import {
   openTownMap,
   closeTownMap,
   closeBuildingOverlay,
+  handleBuildingAction,
 } from './game.js';
 
 window.addEventListener('load', () => {

--- a/src/town.js
+++ b/src/town.js
@@ -11,16 +11,63 @@ function mulberry32(a) {
   };
 }
 
+// Each building type defines its display names, a maximum count per town
+// and a simple placeholder image to use in the building overlay.
 const BUILDINGS = [
-  'Inn',
-  'Blacksmith',
-  'Market',
-  'Temple',
-  'Town Hall',
-  'Tavern',
-  'Stable',
-  'Library',
-  'Alchemist',
+  {
+    type: 'Inn',
+    max: 2,
+    names: ['The Golden Griffin', "Traveler's Rest", 'Silver Stag'],
+    image: 'https://placehold.co/64x64?text=Inn',
+  },
+  {
+    type: 'Blacksmith',
+    max: 1,
+    names: ['Ironforge Smithy', 'Molten Hammer'],
+    image: 'https://placehold.co/64x64?text=Smith',
+  },
+  {
+    type: 'Market',
+    max: 1,
+    names: ['Grand Bazaar', 'Trader Square'],
+    image: 'https://placehold.co/64x64?text=Market',
+  },
+  {
+    type: 'Temple',
+    max: 1,
+    names: ['Temple of Light', 'Shrine of Dawn'],
+    image: 'https://placehold.co/64x64?text=Temple',
+  },
+  {
+    type: 'Town Hall',
+    max: 1,
+    names: ['Town Hall'],
+    image: 'https://placehold.co/64x64?text=Hall',
+  },
+  {
+    type: 'Tavern',
+    max: 2,
+    names: ['The Rusty Flagon', 'The Merry Goose'],
+    image: 'https://placehold.co/64x64?text=Tavern',
+  },
+  {
+    type: 'Stable',
+    max: 1,
+    names: ['Wayfarer Stables'],
+    image: 'https://placehold.co/64x64?text=Stable',
+  },
+  {
+    type: 'Library',
+    max: 1,
+    names: ['Hall of Tomes'],
+    image: 'https://placehold.co/64x64?text=Library',
+  },
+  {
+    type: 'Alchemist',
+    max: 1,
+    names: ['The Crystal Cauldron'],
+    image: 'https://placehold.co/64x64?text=Alch',
+  },
 ];
 
 function generateTown(seed) {
@@ -30,6 +77,10 @@ function generateTown(seed) {
   const grid = [];
   const centerX = Math.floor(width / 2);
   const centerY = Math.floor(height / 2);
+
+  const counts = {};
+  for (const b of BUILDINGS) counts[b.type] = 0;
+
   for (let y = 0; y < height; y++) {
     const row = [];
     for (let x = 0; x < width; x++) {
@@ -40,12 +91,18 @@ function generateTown(seed) {
       }
       const nearRoad = Math.abs(x - centerX) <= 1 || Math.abs(y - centerY) <= 1;
       const chance = nearRoad ? 0.6 : 0.3;
+
       if (rand() < chance) {
-        const name = BUILDINGS[Math.floor(rand() * BUILDINGS.length)];
-        row.push({ x, y, name });
-      } else {
-        row.push(null);
+        const available = BUILDINGS.filter((b) => counts[b.type] < b.max);
+        if (available.length > 0) {
+          const b = available[Math.floor(rand() * available.length)];
+          counts[b.type] += 1;
+          const name = b.names[Math.floor(rand() * b.names.length)];
+          row.push({ x, y, type: b.type, name, image: b.image });
+          continue;
+        }
       }
+      row.push(null);
     }
     grid.push(row);
   }
@@ -75,4 +132,4 @@ function getTown(x, y) {
 // A default town using only the world seed is kept for backward compatibility
 const town = generateTown(worldSeed);
 
-export { generateTown, getTown, town };
+export { generateTown, getTown, town, BUILDINGS };

--- a/src/town.js
+++ b/src/town.js
@@ -19,54 +19,63 @@ const BUILDINGS = [
     max: 2,
     names: ['The Golden Griffin', "Traveler's Rest", 'Silver Stag'],
     image: 'https://placehold.co/64x64?text=Inn',
+    descTemplate: 'You are a DM. Describe {name}, a welcoming inn for weary travellers, in one sentence.',
   },
   {
     type: 'Blacksmith',
     max: 1,
     names: ['Ironforge Smithy', 'Molten Hammer'],
     image: 'https://placehold.co/64x64?text=Smith',
+    descTemplate: 'You are a DM. Describe {name}, a blacksmith\'s shop filled with sparks and anvils, in one sentence.',
   },
   {
     type: 'Market',
     max: 1,
     names: ['Grand Bazaar', 'Trader Square'],
     image: 'https://placehold.co/64x64?text=Market',
+    descTemplate: 'You are a DM. Describe {name}, the bustling market square, in one sentence.',
   },
   {
     type: 'Temple',
     max: 1,
     names: ['Temple of Light', 'Shrine of Dawn'],
     image: 'https://placehold.co/64x64?text=Temple',
+    descTemplate: 'You are a DM. Describe {name}, a quiet place of worship, in one sentence.',
   },
   {
     type: 'Town Hall',
     max: 1,
     names: ['Town Hall'],
     image: 'https://placehold.co/64x64?text=Hall',
+    descTemplate: 'You are a DM. Describe {name}, the administrative heart of the town, in one sentence.',
   },
   {
     type: 'Tavern',
     max: 2,
     names: ['The Rusty Flagon', 'The Merry Goose'],
     image: 'https://placehold.co/64x64?text=Tavern',
+    descTemplate: 'You are a DM. Describe {name}, a lively tavern full of locals, in one sentence.',
   },
   {
     type: 'Stable',
     max: 1,
     names: ['Wayfarer Stables'],
     image: 'https://placehold.co/64x64?text=Stable',
+    descTemplate: 'You are a DM. Describe {name}, the town\'s horse stable, in one sentence.',
   },
   {
     type: 'Library',
     max: 1,
     names: ['Hall of Tomes'],
     image: 'https://placehold.co/64x64?text=Library',
+    descTemplate: 'You are a DM. Describe {name}, a quiet library lined with books, in one sentence.',
   },
   {
     type: 'Alchemist',
     max: 1,
     names: ['The Crystal Cauldron'],
     image: 'https://placehold.co/64x64?text=Alch',
+    descTemplate: 'You are a DM. Describe {name}, an alchemist\'s shop of strange smells, in one sentence.',
   },
 ];
 
@@ -98,7 +107,7 @@ function generateTown(seed) {
           const b = available[Math.floor(rand() * available.length)];
           counts[b.type] += 1;
           const name = b.names[Math.floor(rand() * b.names.length)];
-          row.push({ x, y, type: b.type, name, image: b.image });
+          row.push({ x, y, type: b.type, name, image: b.image, descTemplate: b.descTemplate });
           continue;
         }
       }

--- a/tests/town.test.js
+++ b/tests/town.test.js
@@ -52,3 +52,51 @@ test('town navigation and display', async () => {
   expect(cells[1].className).toContain('bg-amber-500/50');
   expect(document.getElementById('building-name').textContent).not.toBe('');
 });
+
+test('building counts do not exceed limits', async () => {
+  setupStorage();
+  const { generateTown, BUILDINGS } = await import('../src/town.js');
+  const town = generateTown('seed-limit');
+  const counts = {};
+  for (const row of town.grid) {
+    for (const tile of row) {
+      if (tile && tile.type) {
+        counts[tile.type] = (counts[tile.type] || 0) + 1;
+      }
+    }
+  }
+  for (const b of BUILDINGS) {
+    expect((counts[b.type] || 0)).toBeLessThanOrEqual(b.max);
+  }
+});
+
+test('buildings use custom names', async () => {
+  setupStorage();
+  const { generateTown, BUILDINGS } = await import('../src/town.js');
+  const town = generateTown('seed-names');
+  const map = new Map(BUILDINGS.map((b) => [b.type, b.names]));
+  for (const row of town.grid) {
+    for (const tile of row) {
+      if (tile && tile.type) {
+        expect(map.get(tile.type)).toContain(tile.name);
+      }
+    }
+  }
+});
+
+test('building overlay displays image', async () => {
+  setupStorage();
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM(`
+    <div id="building-overlay" class="hidden"></div>
+    <img id="building-overlay-image" />
+    <h3 id="building-overlay-name"></h3>
+  `);
+  global.document = dom.window.document;
+  global.window = dom.window;
+  const { openBuildingOverlay } = await import('../src/game.js');
+  const tile = { name: 'The Golden Griffin', type: 'Inn', image: 'test.png' };
+  openBuildingOverlay(tile);
+  expect(document.getElementById('building-overlay').classList.contains('hidden')).toBe(false);
+  expect(document.getElementById('building-overlay-image').getAttribute('src')).toBe('test.png');
+});

--- a/tests/town.test.js
+++ b/tests/town.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable jest/require-top-level-describe */
+import { jest } from '@jest/globals';
 
 function setupStorage() {
   global.localStorage = {
@@ -51,6 +52,7 @@ test('town navigation and display', async () => {
   const cells = document.getElementById('town-map').children;
   expect(cells[1].className).toContain('bg-amber-500/50');
   expect(document.getElementById('building-name').textContent).not.toBe('');
+  expect(document.querySelectorAll('#town-map img').length).toBeGreaterThan(0);
 });
 
 test('building counts do not exceed limits', async () => {
@@ -91,12 +93,70 @@ test('building overlay displays image', async () => {
     <div id="building-overlay" class="hidden"></div>
     <img id="building-overlay-image" />
     <h3 id="building-overlay-name"></h3>
+    <p id="building-overlay-desc"></p>
+    <div id="building-actions"></div>
+    <div id="building-log"></div>
+    <div id="log"></div>
   `);
   global.document = dom.window.document;
   global.window = dom.window;
-  const { openBuildingOverlay } = await import('../src/game.js');
+  const { openBuildingOverlay, handleBuildingAction, game } = await import('../src/game.js');
+  game.callGemini = jest.fn().mockResolvedValue('desc');
   const tile = { name: 'The Golden Griffin', type: 'Inn', image: 'test.png' };
-  openBuildingOverlay(tile);
+  await openBuildingOverlay(tile);
   expect(document.getElementById('building-overlay').classList.contains('hidden')).toBe(false);
   expect(document.getElementById('building-overlay-image').getAttribute('src')).toBe('test.png');
+  expect(game.callGemini).toHaveBeenCalled();
+  await handleBuildingAction('talk');
+  expect(game.callGemini).toHaveBeenCalledTimes(4);
+});
+
+test('building overlay uses description template when provided', async () => {
+  setupStorage();
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM(`
+    <div id="building-overlay" class="hidden"></div>
+    <img id="building-overlay-image" />
+    <h3 id="building-overlay-name"></h3>
+    <p id="building-overlay-desc"></p>
+    <div id="building-actions"></div>
+    <div id="building-log"></div>
+    <div id="log"></div>
+  `);
+  global.document = dom.window.document;
+  global.window = dom.window;
+  const { openBuildingOverlay, game } = await import('../src/game.js');
+  game.callGemini = jest.fn().mockResolvedValue('desc');
+  const tile = { name: 'The Golden Griffin', type: 'Inn', image: 'test.png', descTemplate: 'Template for {name}' };
+  await openBuildingOverlay(tile);
+  expect(game.callGemini).toHaveBeenCalledWith('Template for The Golden Griffin');
+});
+
+test('escape closes overlays', async () => {
+  setupStorage();
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM(`
+    <div id="town-overlay" class="hidden"></div>
+    <div id="building-overlay" class="hidden"></div>
+    <div id="town-map"></div>
+    <p id="building-name"></p>
+    <button id="open-town"></button>
+    <img id="building-overlay-image" />
+    <p id="building-overlay-desc"></p>
+    <h3 id="building-overlay-name"></h3>
+    <div id="building-actions"></div>
+    <div id="building-log"></div>
+    <div id="log"></div>
+  `);
+  global.document = dom.window.document;
+  global.window = dom.window;
+  const { openTownMap, openBuildingOverlay } = await import('../src/game.js');
+  openTownMap();
+  const tile = { name: 'Inn', type: 'Inn', image: 'x.png' };
+  await openBuildingOverlay(tile);
+  dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Escape' }));
+  expect(document.getElementById('building-overlay').classList.contains('hidden')).toBe(true);
+  expect(document.getElementById('town-overlay').classList.contains('hidden')).toBe(false);
+  dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Escape' }));
+  expect(document.getElementById('town-overlay').classList.contains('hidden')).toBe(true);
 });


### PR DESCRIPTION
## Summary
- give each building type custom names, limits, and image URLs
- display a building image in the overlay
- render town lots using the new building data
- ensure buildings cannot exceed their set limits
- cover new behaviour with tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846121ca100832f90053dd57b39bb0c