### PR TITLE
Improve town interactions and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,11 +133,12 @@
              class="hidden fixed inset-0 bg-black/75 flex items-center justify-center z-50">
           <div class="bg-gray-800 p-6 rounded-lg max-w-sm w-full text-gray-300">
             <h3 id="building-overlay-name" class="text-xl text-amber-100 mb-2"></h3>
-            <img id="building-overlay-image" class="mx-auto mb-4" src="" alt="">
+            <img id="building-overlay-image" class="mx-auto mb-2" src="" alt="">
+            <p id="building-overlay-desc" class="mb-4 text-sm text-gray-400"></p>
             <div class="space-y-2">
-              <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Talk</button>
-              <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Shop</button>
-              <button class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Rest</button>
+              <button id="building-talk" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Talk</button>
+              <button id="building-shop" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Shop</button>
+              <button id="building-rest" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Rest</button>
             </div>
             <button id="close-building" class="mt-4 bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1">Close</button>
           </div>

--- a/index.html
+++ b/index.html
@@ -131,16 +131,17 @@
 
         <div id="building-overlay"
              class="hidden fixed inset-0 bg-black/75 flex items-center justify-center z-50">
-          <div class="bg-gray-800 p-6 rounded-lg max-w-sm w-full text-gray-300">
-            <h3 id="building-overlay-name" class="text-xl text-amber-100 mb-2"></h3>
-            <img id="building-overlay-image" class="mx-auto mb-2" src="" alt="">
-            <p id="building-overlay-desc" class="mb-4 text-sm text-gray-400"></p>
-            <div class="space-y-2">
-              <button id="building-talk" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Talk</button>
-              <button id="building-shop" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Shop</button>
-              <button id="building-rest" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Rest</button>
+          <div class="bg-gray-800 p-6 rounded-lg max-w-2xl w-full text-gray-300 md:grid md:grid-cols-2 md:gap-4">
+            <h3 id="building-overlay-name" class="text-2xl text-amber-100 mb-2 md:col-span-2"></h3>
+            <div class="flex flex-col items-center mb-4 md:mb-0">
+              <img id="building-overlay-image" class="mx-auto mb-4 w-32 h-32 object-cover rounded" src="" alt="">
+              <p id="building-overlay-desc" class="text-sm text-gray-400"></p>
             </div>
-            <button id="close-building" class="mt-4 bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1">Close</button>
+            <div class="flex flex-col">
+              <div id="building-actions" class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4"></div>
+              <div id="building-log" class="bg-black/20 p-2 rounded-md text-xs h-32 overflow-y-auto mb-4"></div>
+              <button id="close-building" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Close</button>
+            </div>
           </div>
         </div>
 

--- a/src/game.js
+++ b/src/game.js
@@ -23,10 +23,13 @@ const gameState = {
   isApiCallInProgress: false,
   worldSeed,
   townState: { x: 0, y: 0 },
+  buildingLogs: {},
 };
 
 let currentTown = null;
 let currentBuilding = null;
+let currentTownCoords = null;
+let currentBuildingKey = null;
 
 const game = {
   init() {
@@ -48,6 +51,7 @@ const game = {
       companions: gameState.companions,
       worldSeed: gameState.worldSeed,
       log: gameState.log,
+      buildingLogs: gameState.buildingLogs,
     };
     localStorage.setItem('aralia-save', JSON.stringify(data));
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -68,6 +72,7 @@ const game = {
       if (Array.isArray(data.inventory)) gameState.inventory = data.inventory;
       if (Array.isArray(data.companions)) gameState.companions = data.companions;
       if (Array.isArray(data.log)) gameState.log = data.log;
+      if (data.buildingLogs && typeof data.buildingLogs === 'object') gameState.buildingLogs = data.buildingLogs;
       if (data.worldSeed) {
         gameState.worldSeed = data.worldSeed;
         world.noise = new SimplexNoise(data.worldSeed);
@@ -401,6 +406,7 @@ function openTownMap() {
     return;
   }
   currentTown = getTown(location.x, location.y);
+  currentTownCoords = { x: location.x, y: location.y };
   gameState.townState = { x: 0, y: 0 };
   const overlay = document.getElementById('town-overlay');
   overlay.classList.remove('hidden');
@@ -443,8 +449,9 @@ function moveTown(dir) {
   game.renderTownMap();
 }
 
-function openBuildingOverlay(tile) {
+async function openBuildingOverlay(tile) {
   currentBuilding = tile;
+  currentBuildingKey = `${currentTownCoords?.x ?? 0},${currentTownCoords?.y ?? 0}-${tile.x},${tile.y}`;
   document.getElementById('building-overlay-name').textContent = tile.name;
   const img = document.getElementById('building-overlay-image');
   if (img) {
@@ -456,8 +463,48 @@ function openBuildingOverlay(tile) {
   document.getElementById('building-overlay').classList.remove('hidden');
   if (descEl) {
     descEl.textContent = '...';
-    game.callGemini(`You are a DM. Describe ${tile.name}, a ${tile.type} in one sentence.`)
-      .then((text) => { if (text) descEl.textContent = text; else descEl.textContent = ''; });
+    let prompt;
+    if (tile.descTemplate) {
+      prompt = tile.descTemplate.replace('{name}', tile.name).replace('{type}', tile.type);
+    } else {
+      prompt = `You are a DM. Describe ${tile.name}, a ${tile.type} in one sentence.`;
+    }
+    const text = await game.callGemini(prompt);
+    if (text) descEl.textContent = text; else descEl.textContent = '';
+  }
+
+  const logContainer = document.getElementById('building-log');
+  if (logContainer) {
+    logContainer.innerHTML = '';
+    (gameState.buildingLogs[currentBuildingKey] || []).slice().reverse().forEach((msg) => {
+      const p = document.createElement('p');
+      p.textContent = msg;
+      p.className = 'text-gray-400';
+      logContainer.appendChild(p);
+    });
+  }
+  await generateBuildingActions();
+}
+
+async function generateBuildingActions() {
+  const actionsContainer = document.getElementById('building-actions');
+  if (!actionsContainer || !currentBuilding) return;
+  actionsContainer.innerHTML = '<div class="sm:col-span-2 flex justify-center items-center"><span class="spinner"></span><p class="ml-2">Thinking...</p></div>';
+  const recent = (gameState.buildingLogs[currentBuildingKey] || []).slice(0, 3).join(' | ');
+  const prompt = `You are a DM for a fantasy RPG. The player is in ${currentBuilding.name}, a ${currentBuilding.type}. Recent events: ${recent}. Provide a comma-separated list of exactly 4 short actions (1-3 words each) they can take inside.`;
+  const actionsString = await game.callGemini(prompt);
+  actionsContainer.innerHTML = '';
+  if (actionsString) {
+    actionsString.split(',').map(a => a.trim()).slice(0,4).forEach((text) => {
+      if (!text) return;
+      const btn = document.createElement('button');
+      btn.textContent = text;
+      btn.className = 'bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 text-base w-full whitespace-normal';
+      btn.onclick = () => handleBuildingAction(text);
+      actionsContainer.appendChild(btn);
+    });
+  } else {
+    actionsContainer.innerHTML = '<p class="text-gray-500 sm:col-span-2">Could not get actions.</p>';
   }
 }
 
@@ -468,13 +515,26 @@ function closeBuildingOverlay() {
   const descEl = document.getElementById('building-overlay-desc');
   if (descEl) descEl.textContent = '';
   currentBuilding = null;
+  currentBuildingKey = null;
 }
 
 async function handleBuildingAction(action) {
   if (!currentBuilding) return;
   const prompt = `You are a DM. The player chooses to ${action} at ${currentBuilding.name}, a ${currentBuilding.type}. Respond in one short sentence.`;
   const text = await game.callGemini(prompt);
-  if (text) game.logMessage(text);
+  if (text) {
+    if (!gameState.buildingLogs[currentBuildingKey]) gameState.buildingLogs[currentBuildingKey] = [];
+    gameState.buildingLogs[currentBuildingKey].unshift(text);
+    if (gameState.buildingLogs[currentBuildingKey].length > 50) gameState.buildingLogs[currentBuildingKey].pop();
+    const logContainer = document.getElementById('building-log');
+    if (logContainer) {
+      const p = document.createElement('p');
+      p.textContent = text;
+      p.className = 'text-gray-400';
+      logContainer.prepend(p);
+    }
+  }
+  generateBuildingActions();
 }
 
 function openCompanion(index) {

--- a/src/main.js
+++ b/src/main.js
@@ -23,9 +23,6 @@ window.addEventListener('load', () => {
   document.getElementById('open-town').addEventListener('click', openTownMap);
   document.getElementById('close-town').addEventListener('click', closeTownMap);
   document.getElementById('close-building').addEventListener('click', closeBuildingOverlay);
-  document.getElementById('building-talk').addEventListener('click', () => handleBuildingAction('talk'));
-  document.getElementById('building-shop').addEventListener('click', () => handleBuildingAction('shop'));
-  document.getElementById('building-rest').addEventListener('click', () => handleBuildingAction('rest'));
   document.getElementById('open-glossary').addEventListener('click', openGlossary);
   document.getElementById('close-glossary').addEventListener('click', closeGlossary);
   document.getElementById('save-game').addEventListener('click', () => game.saveGame());

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import {
   openTownMap,
   closeTownMap,
   closeBuildingOverlay,
+  handleBuildingAction,
 } from './game.js';
 
 window.addEventListener('load', () => {
@@ -22,6 +23,9 @@ window.addEventListener('load', () => {
   document.getElementById('open-town').addEventListener('click', openTownMap);
   document.getElementById('close-town').addEventListener('click', closeTownMap);
   document.getElementById('close-building').addEventListener('click', closeBuildingOverlay);
+  document.getElementById('building-talk').addEventListener('click', () => handleBuildingAction('talk'));
+  document.getElementById('building-shop').addEventListener('click', () => handleBuildingAction('shop'));
+  document.getElementById('building-rest').addEventListener('click', () => handleBuildingAction('rest'));
   document.getElementById('open-glossary').addEventListener('click', openGlossary);
   document.getElementById('close-glossary').addEventListener('click', closeGlossary);
   document.getElementById('save-game').addEventListener('click', () => game.saveGame());

--- a/src/town.js
+++ b/src/town.js
@@ -19,54 +19,63 @@ const BUILDINGS = [
     max: 2,
     names: ['The Golden Griffin', "Traveler's Rest", 'Silver Stag'],
     image: 'https://placehold.co/64x64?text=Inn',
+    descTemplate: 'You are a DM. Describe {name}, a welcoming inn for weary travellers, in one sentence.',
   },
   {
     type: 'Blacksmith',
     max: 1,
     names: ['Ironforge Smithy', 'Molten Hammer'],
     image: 'https://placehold.co/64x64?text=Smith',
+    descTemplate: 'You are a DM. Describe {name}, a blacksmith\'s shop filled with sparks and anvils, in one sentence.',
   },
   {
     type: 'Market',
     max: 1,
     names: ['Grand Bazaar', 'Trader Square'],
     image: 'https://placehold.co/64x64?text=Market',
+    descTemplate: 'You are a DM. Describe {name}, the bustling market square, in one sentence.',
   },
   {
     type: 'Temple',
     max: 1,
     names: ['Temple of Light', 'Shrine of Dawn'],
     image: 'https://placehold.co/64x64?text=Temple',
+    descTemplate: 'You are a DM. Describe {name}, a quiet place of worship, in one sentence.',
   },
   {
     type: 'Town Hall',
     max: 1,
     names: ['Town Hall'],
     image: 'https://placehold.co/64x64?text=Hall',
+    descTemplate: 'You are a DM. Describe {name}, the administrative heart of the town, in one sentence.',
   },
   {
     type: 'Tavern',
     max: 2,
     names: ['The Rusty Flagon', 'The Merry Goose'],
     image: 'https://placehold.co/64x64?text=Tavern',
+    descTemplate: 'You are a DM. Describe {name}, a lively tavern full of locals, in one sentence.',
   },
   {
     type: 'Stable',
     max: 1,
     names: ['Wayfarer Stables'],
     image: 'https://placehold.co/64x64?text=Stable',
+    descTemplate: 'You are a DM. Describe {name}, the town\'s horse stable, in one sentence.',
   },
   {
     type: 'Library',
     max: 1,
     names: ['Hall of Tomes'],
     image: 'https://placehold.co/64x64?text=Library',
+    descTemplate: 'You are a DM. Describe {name}, a quiet library lined with books, in one sentence.',
   },
   {
     type: 'Alchemist',
     max: 1,
     names: ['The Crystal Cauldron'],
     image: 'https://placehold.co/64x64?text=Alch',
+    descTemplate: 'You are a DM. Describe {name}, an alchemist\'s shop of strange smells, in one sentence.',
   },
 ];
 
@@ -98,7 +107,7 @@ function generateTown(seed) {
           const b = available[Math.floor(rand() * available.length)];
           counts[b.type] += 1;
           const name = b.names[Math.floor(rand() * b.names.length)];
-          row.push({ x, y, type: b.type, name, image: b.image });
+          row.push({ x, y, type: b.type, name, image: b.image, descTemplate: b.descTemplate });
           continue;
         }
       }

--- a/tests/town.test.js
+++ b/tests/town.test.js
@@ -94,6 +94,8 @@ test('building overlay displays image', async () => {
     <img id="building-overlay-image" />
     <h3 id="building-overlay-name"></h3>
     <p id="building-overlay-desc"></p>
+    <div id="building-actions"></div>
+    <div id="building-log"></div>
     <div id="log"></div>
   `);
   global.document = dom.window.document;
@@ -101,13 +103,33 @@ test('building overlay displays image', async () => {
   const { openBuildingOverlay, handleBuildingAction, game } = await import('../src/game.js');
   game.callGemini = jest.fn().mockResolvedValue('desc');
   const tile = { name: 'The Golden Griffin', type: 'Inn', image: 'test.png' };
-  openBuildingOverlay(tile);
-  await Promise.resolve();
+  await openBuildingOverlay(tile);
   expect(document.getElementById('building-overlay').classList.contains('hidden')).toBe(false);
   expect(document.getElementById('building-overlay-image').getAttribute('src')).toBe('test.png');
   expect(game.callGemini).toHaveBeenCalled();
   await handleBuildingAction('talk');
-  expect(game.callGemini).toHaveBeenCalledTimes(2);
+  expect(game.callGemini).toHaveBeenCalledTimes(4);
+});
+
+test('building overlay uses description template when provided', async () => {
+  setupStorage();
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM(`
+    <div id="building-overlay" class="hidden"></div>
+    <img id="building-overlay-image" />
+    <h3 id="building-overlay-name"></h3>
+    <p id="building-overlay-desc"></p>
+    <div id="building-actions"></div>
+    <div id="building-log"></div>
+    <div id="log"></div>
+  `);
+  global.document = dom.window.document;
+  global.window = dom.window;
+  const { openBuildingOverlay, game } = await import('../src/game.js');
+  game.callGemini = jest.fn().mockResolvedValue('desc');
+  const tile = { name: 'The Golden Griffin', type: 'Inn', image: 'test.png', descTemplate: 'Template for {name}' };
+  await openBuildingOverlay(tile);
+  expect(game.callGemini).toHaveBeenCalledWith('Template for The Golden Griffin');
 });
 
 test('escape closes overlays', async () => {
@@ -122,6 +144,8 @@ test('escape closes overlays', async () => {
     <img id="building-overlay-image" />
     <p id="building-overlay-desc"></p>
     <h3 id="building-overlay-name"></h3>
+    <div id="building-actions"></div>
+    <div id="building-log"></div>
     <div id="log"></div>
   `);
   global.document = dom.window.document;
@@ -129,7 +153,7 @@ test('escape closes overlays', async () => {
   const { openTownMap, openBuildingOverlay } = await import('../src/game.js');
   openTownMap();
   const tile = { name: 'Inn', type: 'Inn', image: 'x.png' };
-  openBuildingOverlay(tile);
+  await openBuildingOverlay(tile);
   dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Escape' }));
   expect(document.getElementById('building-overlay').classList.contains('hidden')).toBe(true);
   expect(document.getElementById('town-overlay').classList.contains('hidden')).toBe(false);


### PR DESCRIPTION
## Summary
- add building action buttons and descriptions
- display building images on town map
- support ESC key to close town and building overlays
- wire up building event handlers
- expand town unit tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461400ed54832f930eb549c52d06fa