### PR TITLE
Improve town building overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,13 +131,17 @@
 
         <div id="building-overlay"
              class="hidden fixed inset-0 bg-black/75 flex items-center justify-center z-50">
-          <div class="bg-gray-800 p-6 rounded-lg max-w-md w-full text-gray-300">
-            <h3 id="building-overlay-name" class="text-2xl text-amber-100 mb-2"></h3>
-            <img id="building-overlay-image" class="mx-auto mb-4 w-32 h-32 object-cover rounded" src="" alt="">
-            <p id="building-overlay-desc" class="mb-4 text-sm text-gray-400"></p>
-            <div id="building-actions" class="grid grid-cols-2 gap-2 mb-4"></div>
-            <div id="building-log" class="bg-black/20 p-2 rounded-md text-xs h-32 overflow-y-auto mb-4"></div>
-            <button id="close-building" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Close</button>
+          <div class="bg-gray-800 p-6 rounded-lg max-w-2xl w-full text-gray-300 md:grid md:grid-cols-2 md:gap-4">
+            <h3 id="building-overlay-name" class="text-2xl text-amber-100 mb-2 md:col-span-2"></h3>
+            <div class="flex flex-col items-center mb-4 md:mb-0">
+              <img id="building-overlay-image" class="mx-auto mb-4 w-32 h-32 object-cover rounded" src="" alt="">
+              <p id="building-overlay-desc" class="text-sm text-gray-400"></p>
+            </div>
+            <div class="flex flex-col">
+              <div id="building-actions" class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4"></div>
+              <div id="building-log" class="bg-black/20 p-2 rounded-md text-xs h-32 overflow-y-auto mb-4"></div>
+              <button id="close-building" class="bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 w-full">Close</button>
+            </div>
           </div>
         </div>
 

--- a/src/game.js
+++ b/src/game.js
@@ -463,7 +463,13 @@ async function openBuildingOverlay(tile) {
   document.getElementById('building-overlay').classList.remove('hidden');
   if (descEl) {
     descEl.textContent = '...';
-    const text = await game.callGemini(`You are a DM. Describe ${tile.name}, a ${tile.type} in one sentence.`);
+    let prompt;
+    if (tile.descTemplate) {
+      prompt = tile.descTemplate.replace('{name}', tile.name).replace('{type}', tile.type);
+    } else {
+      prompt = `You are a DM. Describe ${tile.name}, a ${tile.type} in one sentence.`;
+    }
+    const text = await game.callGemini(prompt);
     if (text) descEl.textContent = text; else descEl.textContent = '';
   }
 
@@ -483,9 +489,9 @@ async function openBuildingOverlay(tile) {
 async function generateBuildingActions() {
   const actionsContainer = document.getElementById('building-actions');
   if (!actionsContainer || !currentBuilding) return;
-  actionsContainer.innerHTML = '<div class="col-span-2 flex justify-center items-center"><span class="spinner"></span><p class="ml-2">Thinking...</p></div>';
+  actionsContainer.innerHTML = '<div class="sm:col-span-2 flex justify-center items-center"><span class="spinner"></span><p class="ml-2">Thinking...</p></div>';
   const recent = (gameState.buildingLogs[currentBuildingKey] || []).slice(0, 3).join(' | ');
-  const prompt = `You are a DM for a fantasy RPG. The player is in ${currentBuilding.name}, a ${currentBuilding.type}. Recent events: ${recent}. Provide a comma-separated list of exactly 4 actions they can take inside.`;
+  const prompt = `You are a DM for a fantasy RPG. The player is in ${currentBuilding.name}, a ${currentBuilding.type}. Recent events: ${recent}. Provide a comma-separated list of exactly 4 short actions (1-3 words each) they can take inside.`;
   const actionsString = await game.callGemini(prompt);
   actionsContainer.innerHTML = '';
   if (actionsString) {
@@ -493,12 +499,12 @@ async function generateBuildingActions() {
       if (!text) return;
       const btn = document.createElement('button');
       btn.textContent = text;
-      btn.className = 'bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 text-sm';
+      btn.className = 'bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 text-base w-full whitespace-normal';
       btn.onclick = () => handleBuildingAction(text);
       actionsContainer.appendChild(btn);
     });
   } else {
-    actionsContainer.innerHTML = '<p class="text-gray-500 col-span-2">Could not get actions.</p>';
+    actionsContainer.innerHTML = '<p class="text-gray-500 sm:col-span-2">Could not get actions.</p>';
   }
 }
 

--- a/src/town.js
+++ b/src/town.js
@@ -19,54 +19,63 @@ const BUILDINGS = [
     max: 2,
     names: ['The Golden Griffin', "Traveler's Rest", 'Silver Stag'],
     image: 'https://placehold.co/64x64?text=Inn',
+    descTemplate: 'You are a DM. Describe {name}, a welcoming inn for weary travellers, in one sentence.',
   },
   {
     type: 'Blacksmith',
     max: 1,
     names: ['Ironforge Smithy', 'Molten Hammer'],
     image: 'https://placehold.co/64x64?text=Smith',
+    descTemplate: 'You are a DM. Describe {name}, a blacksmith\'s shop filled with sparks and anvils, in one sentence.',
   },
   {
     type: 'Market',
     max: 1,
     names: ['Grand Bazaar', 'Trader Square'],
     image: 'https://placehold.co/64x64?text=Market',
+    descTemplate: 'You are a DM. Describe {name}, the bustling market square, in one sentence.',
   },
   {
     type: 'Temple',
     max: 1,
     names: ['Temple of Light', 'Shrine of Dawn'],
     image: 'https://placehold.co/64x64?text=Temple',
+    descTemplate: 'You are a DM. Describe {name}, a quiet place of worship, in one sentence.',
   },
   {
     type: 'Town Hall',
     max: 1,
     names: ['Town Hall'],
     image: 'https://placehold.co/64x64?text=Hall',
+    descTemplate: 'You are a DM. Describe {name}, the administrative heart of the town, in one sentence.',
   },
   {
     type: 'Tavern',
     max: 2,
     names: ['The Rusty Flagon', 'The Merry Goose'],
     image: 'https://placehold.co/64x64?text=Tavern',
+    descTemplate: 'You are a DM. Describe {name}, a lively tavern full of locals, in one sentence.',
   },
   {
     type: 'Stable',
     max: 1,
     names: ['Wayfarer Stables'],
     image: 'https://placehold.co/64x64?text=Stable',
+    descTemplate: 'You are a DM. Describe {name}, the town\'s horse stable, in one sentence.',
   },
   {
     type: 'Library',
     max: 1,
     names: ['Hall of Tomes'],
     image: 'https://placehold.co/64x64?text=Library',
+    descTemplate: 'You are a DM. Describe {name}, a quiet library lined with books, in one sentence.',
   },
   {
     type: 'Alchemist',
     max: 1,
     names: ['The Crystal Cauldron'],
     image: 'https://placehold.co/64x64?text=Alch',
+    descTemplate: 'You are a DM. Describe {name}, an alchemist\'s shop of strange smells, in one sentence.',
   },
 ];
 
@@ -98,7 +107,7 @@ function generateTown(seed) {
           const b = available[Math.floor(rand() * available.length)];
           counts[b.type] += 1;
           const name = b.names[Math.floor(rand() * b.names.length)];
-          row.push({ x, y, type: b.type, name, image: b.image });
+          row.push({ x, y, type: b.type, name, image: b.image, descTemplate: b.descTemplate });
           continue;
         }
       }

--- a/tests/town.test.js
+++ b/tests/town.test.js
@@ -111,6 +111,27 @@ test('building overlay displays image', async () => {
   expect(game.callGemini).toHaveBeenCalledTimes(4);
 });
 
+test('building overlay uses description template when provided', async () => {
+  setupStorage();
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM(`
+    <div id="building-overlay" class="hidden"></div>
+    <img id="building-overlay-image" />
+    <h3 id="building-overlay-name"></h3>
+    <p id="building-overlay-desc"></p>
+    <div id="building-actions"></div>
+    <div id="building-log"></div>
+    <div id="log"></div>
+  `);
+  global.document = dom.window.document;
+  global.window = dom.window;
+  const { openBuildingOverlay, game } = await import('../src/game.js');
+  game.callGemini = jest.fn().mockResolvedValue('desc');
+  const tile = { name: 'The Golden Griffin', type: 'Inn', image: 'test.png', descTemplate: 'Template for {name}' };
+  await openBuildingOverlay(tile);
+  expect(game.callGemini).toHaveBeenCalledWith('Template for The Golden Griffin');
+});
+
 test('escape closes overlays', async () => {
   setupStorage();
   const { JSDOM } = await import('jsdom');


### PR DESCRIPTION
## Summary
- make building overlay larger and add two-column layout
- enlarge building action buttons and let them wrap
- ask Gemini for short action labels
- support custom building description templates
- add regression test for description template usage

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846fb7cb86c832f94dc7ae997ff5cb1