### PR TITLE
Fix main menu overlay visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,9 +149,8 @@
           </div>
         </div>
 
-        <div id="main-menu-container"></div>
-
         </main>
+        <div id="main-menu-container"></div>
     </div>
 
     <script>

--- a/main-menu.js
+++ b/main-menu.js
@@ -14,7 +14,8 @@ function showMainMenu() {
     const mainEl = document.querySelector('main');
     if (mainEl) mainEl.style.display = 'none';
     document.querySelector('header').style.filter = 'blur(4px)';
-    document.getElementById('main-menu-overlay').classList.remove('hidden');
+    const overlay = document.getElementById('main-menu-overlay');
+    if (overlay) overlay.classList.remove('hidden');
 
     const saveButton = document.getElementById('menu-save-game');
     if (typeof game === 'undefined' || !game || typeof game.saveGame !== 'function') {
@@ -35,7 +36,8 @@ function hideMainMenu() {
     const mainEl = document.querySelector('main');
     if (mainEl) mainEl.style.display = '';
     document.querySelector('header').style.filter = '';
-    document.getElementById('main-menu-overlay').classList.add('hidden');
+    const overlay = document.getElementById('main-menu-overlay');
+    if (overlay) overlay.classList.add('hidden');
 }
 
 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- move `main-menu-container` after the `<main>` tag in `index.html`
- add overlay element checks when showing or hiding the main menu

## Testing
- `npm test`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68492571dff8832f9fcbdb77167e7c1d