### PR TITLE
This commit adds JSON data for 16 D&D 5th Edition expansion player ra…

### DIFF
--- a/game_data/races/README.md
+++ b/game_data/races/README.md
@@ -1,0 +1,75 @@
+# D&D 5e Race Data (SRD)
+
+This directory contains JSON files with information about D&D 5th Edition races, focusing on content available under the System Reference Document (SRD).
+
+## Source
+
+Data was primarily scraped from the D&D 5th Edition SRD section on [roll20.net](https://roll20.net/compendium/dnd5e/).
+
+## JSON File Structure
+
+Each `.json` file in this directory representing an SRD race (e.g., `dragonborn.json`, `elf.json`, `half_elf.json`) generally follows the structure below:
+
+*   `name`: (String) The name of the race (e.g., "Elf", "Dwarf").
+*   `source`: (String) The source document from which the information was derived (e.g., "Free Basic Rules (2014)").
+*   `description`: (String) A general introductory paragraph for the race.
+*   `ability_score_increase`: (Object) Contains details about ability score modifications.
+    *   `description`: (String) The textual description of the ASI (e.g., "Your Dexterity score increases by 2.").
+    *   `abilities`: (Array of Objects) Lists fixed ability score increases.
+        *   `name`: (String) The name of the ability (e.g., "Dexterity").
+        *   `increase`: (Integer) The amount of the increase.
+    *   `choose`: (Object, Optional) If the race allows choosing ASIs.
+        *   `count`: (Integer) The number of abilities to choose.
+        *   `from`: (Array of Strings) A list of abilities to choose from.
+        *   `increase`: (Integer) The amount of the increase for chosen abilities.
+*   `age`: (Object)
+    *   `description`: (String) Textual description of the race's age and lifespan.
+*   `alignment`: (Object)
+    *   `description`: (String) Textual description of typical alignment tendencies.
+*   `size`: (Object)
+    *   `name`: (String) The size category (e.g., "Medium", "Small").
+    *   `description`: (String) Textual description of height, weight, and general build.
+*   `speed`: (Object)
+    *   `base`: (Integer) The base walking speed in feet.
+    *   `description`: (String) Textual description of speed, may include notes on armor.
+*   `languages`: (Object) Describes language proficiencies.
+    *   `static`: (Array of Strings) Languages all members of the race know.
+    *   `choose`: (Object, Optional) If the race allows choosing additional languages.
+        *   `count`: (Integer) The number of languages to choose.
+        *   `from`: (String/Array of Strings) Description of where to choose from (e.g., "any standard language").
+    *   `description`: (String) Full textual description of language proficiencies.
+*   `traits`: (Array of Objects) Each object represents a racial trait.
+    *   `name`: (String) The name of the trait (e.g., "Darkvision", "Fey Ancestry").
+    *   `description`: (String) The textual description of the trait.
+    *   `options_description`: (String, Optional) If the trait has complex options that were not fully parsed, this field might contain the original text.
+    *   `options`: (Array of Objects, Optional) For traits with specific choices (e.g., Draconic Ancestry options for Dragonborn). Each option object will have its own relevant fields.
+    *   `spells`: (Array of Objects, Optional) For traits granting spells (e.g., Tiefling's Infernal Legacy).
+        *   `name`: (String) Spell name.
+        *   `level_requirement`: (Integer) Character level to gain the spell.
+        *   `type`: (String) e.g., "cantrip", "spell".
+        *   `usage`: (String) e.g., "at will", "once per long rest".
+        *   `spell_level_cast_at`: (Integer, Optional) If the spell is cast at a specific level.
+        *   `spellcasting_ability`: (String) The ability score used for these spells.
+*   `subraces`: (Array of Objects) Each object represents a subrace and generally follows a similar structure to the main race, detailing its unique name, description, ability score increases, and traits.
+
+## Usage
+
+This data is intended for use in applications such as D&D character builders, dynamic tooltips, or any system that needs structured information about player races.
+
+## TODO Comments
+
+Some fields, particularly within complex `traits` or `options_description`, may contain `// TODO:` comments. This indicates areas where the automated parsing was ambiguous or could not fully structure the data. These sections may require manual review, cross-referencing with official SRD sources, or more sophisticated parsing logic to be fully utilized.
+
+## Expansion Race Data
+
+This directory now also includes JSON files for various races and variants from D&D 5e expansion sourcebooks.
+
+The primary source for this information is `dnd5e.wikidot.com`, and specific sourcebooks like 'Mordenkainen Presents: Monsters of the Multiverse' (MPMM), 'Eberron - Rising from the Last War' (ERLW), 'Volo's Guide to Monsters' (VGtM), and 'Elemental Evil Player's Companion' (EEPC) are noted within each file.
+
+**File Structure for Expansion Races:** Each expansion race file (e.g., `aasimar.json`, `shifter.json`) contains a top-level `"name"` for the broad race concept and a `"variants"` array. Each object within the `"variants"` array represents a distinct published version of that race (e.g., its MPMM version, an Eberron-specific version, or an older version from a book like Volo's Guide).
+
+Each variant object details its specific `"version_name"`, `"source"` (including a URL to the wikidot page), `"ability_score_increase"`, `"size"`, `"speed"`, `"creature_type"`, `"traits"`, and `"languages"`.
+
+This structure allows for multiple official versions of a race to be represented and chosen from.
+
+As this data is transcribed from a public wiki, always cross-reference with official source material if precise wording or mechanics are critical for your application.

--- a/game_data/races/aasimar.json
+++ b/game_data/races/aasimar.json
@@ -1,0 +1,229 @@
+{
+  "name": "Aasimar",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/aasimar",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Celestial Resistance",
+          "description": "You have resistance to necrotic damage and radiant damage."
+        },
+        {
+          "name": "Healing Hands",
+          "description": "As an action, you can touch a creature and roll a number of d4s equal to your proficiency bonus. The creature regains a number of hit points equal to the total rolled. Once you use this trait, you can’t use it again until you finish a long rest."
+        },
+        {
+          "name": "Light Bearer",
+          "description": "You know the Light cantrip. Charisma is your spellcasting ability for it."
+        },
+        {
+          "name": "Celestial Revelation",
+          "description": "When you reach 3rd level, choose one of the revelation options below. Thereafter, you can use a bonus action to unleash the celestial energy within yourself, gaining the benefits of that revelation. Your transformation lasts for 1 minute or until you end it as a bonus action. Once you transform using your revelation below, you can’t use it again until you finish a long rest:",
+          "options_description": "// TODO: Parse the following options into a structured list if possible, for now it's a single string.\nNecrotic Shroud. Your eyes briefly become pools of darkness, and ghostly, flightless wings sprout from your back temporarily. Creatures other than your allies within 10 feet of you that can see you must succeed on a Charisma saving throw (DC 8 + your proficiency bonus + your Charisma modifier) or become frightened of you until the end of your next turn. Until the transformation ends, once on each of your turns, you can deal extra necrotic damage to one target when you deal damage to it with an attack or a spell. The extra damage equals your proficiency bonus.\nRadiant Consumption. Searing light temporarily radiates from your eyes and mouth. For the duration, you shed bright light in a 10-foot radius and dim light for an additional 10 feet, and at the end of each of your turns, each creature within 10 feet of you takes radiant damage equal to your proficiency bonus. Until the transformation ends, once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra damage equals your proficiency bonus.\nRadiant Soul. Two luminous, spectral wings sprout from your back temporarily. Until the transformation ends, you have a flying speed equal to your walking speed, and once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra damage equals your proficiency bonus.",
+          "options": [
+            {
+              "name": "Necrotic Shroud",
+              "description": "Your eyes briefly become pools of darkness, and ghostly, flightless wings sprout from your back temporarily. Creatures other than your allies within 10 feet of you that can see you must succeed on a Charisma saving throw (DC 8 + your proficiency bonus + your Charisma modifier) or become frightened of you until the end of your next turn. Until the transformation ends, once on each of your turns, you can deal extra necrotic damage to one target when you deal damage to it with an attack or a spell. The extra damage equals your proficiency bonus."
+            },
+            {
+              "name": "Radiant Consumption",
+              "description": "Searing light temporarily radiates from your eyes and mouth. For the duration, you shed bright light in a 10-foot radius and dim light for an additional 10 feet, and at the end of each of your turns, each creature within 10 feet of you takes radiant damage equal to your proficiency bonus. Until the transformation ends, once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra damage equals your proficiency bonus."
+            },
+            {
+              "name": "Radiant Soul",
+              "description": "Two luminous, spectral wings sprout from your back temporarily. Until the transformation ends, you have a flying speed equal to your walking speed, and once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra damage equals your proficiency bonus."
+            }
+          ]
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Volo's Guide - Protector",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/aasimar",
+      "ability_score_increase": [
+        {
+          "ability": "Charisma",
+          "increase": 2
+        },
+        {
+          "ability": "Wisdom",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "Blessed with a radiant soul, your vision can easily cut through darkness. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Celestial Resistance",
+          "description": "You have resistance to necrotic damage and radiant damage."
+        },
+        {
+          "name": "Healing Hands",
+          "description": "As an action, you can touch a creature and cause it to regain a number of hit points equal to your level. Once you use this trait, you can't use it again until you finish a long rest."
+        },
+        {
+          "name": "Light Bearer",
+          "description": "You know the Light cantrip. Charisma is your spellcasting ability for it."
+        },
+        {
+          "name": "Radiant Soul (Protector)",
+          "description": "Starting at 3rd level, you can use your action to unleash the divine energy within yourself, causing your eyes to glimmer and two luminous, incorporeal wings to sprout from your back.\nYour transformation lasts for 1 minute or until you end it as a bonus action. During it, you have a flying speed of 30 feet, and once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra radiant damage equals your level.\nOnce you use this trait, you can't use it again until you finish a long rest."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Celestial"
+        ]
+      }
+    },
+    {
+      "version_name": "Volo's Guide - Scourge",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/aasimar",
+      "ability_score_increase": [
+        {
+          "ability": "Charisma",
+          "increase": 2
+        },
+        {
+          "ability": "Constitution",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "Blessed with a radiant soul, your vision can easily cut through darkness. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Celestial Resistance",
+          "description": "You have resistance to necrotic damage and radiant damage."
+        },
+        {
+          "name": "Healing Hands",
+          "description": "As an action, you can touch a creature and cause it to regain a number of hit points equal to your level. Once you use this trait, you can't use it again until you finish a long rest."
+        },
+        {
+          "name": "Light Bearer",
+          "description": "You know the Light cantrip. Charisma is your spellcasting ability for it."
+        },
+        {
+          "name": "Radiant Consumption (Scourge)",
+          "description": "Starting at 3rd level, you can use your action to unleash the divine energy within yourself, causing a searing light to radiate from you, pour out of your eyes and mouth, and threaten to char you.\nYour transformation lasts for 1 minute or until you end it as a bonus action. During it, you shed bright light in a 10-foot radius and dim light for an additional 10 feet, and at the end of each of your turns, you and each creature within 10 feet of you take radiant damage equal to half your level (rounded up). In addition, once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra radiant damage equals your level.\nOnce you use this trait, you can't use it again until you finish a long rest."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Celestial"
+        ]
+      }
+    },
+    {
+      "version_name": "Volo's Guide - Fallen",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/aasimar",
+      "ability_score_increase": [
+        {
+          "ability": "Charisma",
+          "increase": 2
+        },
+        {
+          "ability": "Strength",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "Blessed with a radiant soul, your vision can easily cut through darkness. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Celestial Resistance",
+          "description": "You have resistance to necrotic damage and radiant damage."
+        },
+        {
+          "name": "Healing Hands",
+          "description": "As an action, you can touch a creature and cause it to regain a number of hit points equal to your level. Once you use this trait, you can't use it again until you finish a long rest."
+        },
+        {
+          "name": "Light Bearer",
+          "description": "You know the Light cantrip. Charisma is your spellcasting ability for it."
+        },
+        {
+          "name": "Necrotic Shroud (Fallen)",
+          "description": "Starting at 3rd level, you can use your action to unleash the divine energy within yourself, causing your eyes to turn into pools of darkness and two skeletal, ghostly, flightless wings to sprout from your back. The instant you transform, other creatures within 10 feet of you that can see you must each succeed on a Charisma saving throw (DC 8 + your proficiency bonus + your Charisma modifier) or become frightened of you until the end of your next turn.\nYour transformation lasts for 1 minute or until you end it as a bonus action. During it, once on each of your turns, you can deal extra necrotic damage to one target when you deal damage to it with an attack or a spell. The extra necrotic damage equals your level.\nOnce you use this trait, you can't use it again until you finish a long rest."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Celestial"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/changeling.json
+++ b/game_data/races/changeling.json
@@ -1,0 +1,101 @@
+{
+  "name": "Changeling",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/changeling",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Fey",
+      "traits": [
+        {
+          "name": "Changeling Instincts",
+          "description": "Thanks to your connection to the fey realm, you gain proficiency with two of the following skills of your choice: Deception, Insight, Intimidation, Performance, or Persuasion."
+        },
+        {
+          "name": "Shapechanger",
+          "description": "As an action, you can change your appearance and your voice. You determine the specifics of the changes, including your coloration, hair length, and sex. You can also adjust your height and weight and can change your size between Medium and Small. You can make yourself appear as a member of another race, though none of your game statistics change. You can’t duplicate the appearance of an individual you’ve never seen, and you must adopt a form that has the same basic arrangement of limbs that you have. Your clothing and equipment aren’t changed by this trait.\nYou stay in the new form until you use an action to revert to your true form or until you die."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Eberron - Rising from the Last War",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/changeling",
+      "ability_score_increase": [
+        {
+          "ability": "Charisma",
+          "increase": 2
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "one other ability score of your choice increases by 1."
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Shapechanger",
+          "description": "As an action, you can change your appearance and your voice. You determine the specifics of the changes, including your coloration, hair length, and sex. You can also adjust your height and weight, but not so much that your size changes. You can make yourself appear as a member of another race, though none of your game statistics change. You can't duplicate the appearance of a creature you've never seen, and you must adopt a form that has the same basic arrangement of limbs that you have. Your clothing and equipment aren't changed by this trait.\nYou stay in the new form until you use an action to revert to your true form or until you die."
+        },
+        {
+          "name": "Changeling Instincts",
+          "description": "You gain proficiency with two of the following skills of your choice: Deception, Insight, Intimidation, and Persuasion."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 2,
+        "options_description": "two other languages of your choice."
+      }
+    }
+  ]
+}

--- a/game_data/races/dragonborn.json
+++ b/game_data/races/dragonborn.json
@@ -1,0 +1,108 @@
+{
+  "name": "Dragonborn",
+  "source": "Free Basic Rules (2014)",
+  "description": "Your draconic heritage manifests in a variety of traits you share with other dragonborn.",
+  "ability_score_increase": {
+    "description": "Your Strength score increases by 2, and your Charisma score increases by 1.",
+    "abilities": [
+      {
+        "name": "Strength",
+        "increase": 2
+      },
+      {
+        "name": "Charisma",
+        "increase": 1
+      }
+    ]
+  },
+  "age": {
+    "description": "Young dragonborn grow quickly. They walk hours after hatching, attain the size and development of a 10-year-old human child by the age of 3, and reach adulthood by 15. They live to be around 80."
+  },
+  "alignment": {
+    "description": "Dragonborn tend to extremes, making a conscious choice for one side or the other in the cosmic war between good and evil. Most dragonborn are good, but those who side with evil can be terrible villains."
+  },
+  "size": {
+    "name": "Medium",
+    "description": "Dragonborn are taller and heavier than humans, standing well over 6 feet tall and averaging almost 250 pounds. Your size is Medium."
+  },
+  "speed": {
+    "base": 30,
+    "description": "Your base walking speed is 30 feet."
+  },
+  "languages": {
+    "chosen": [],
+    "options": [],
+    "static": [
+      "Common",
+      "Draconic"
+    ],
+    "description": "You can speak, read, and write Common and Draconic. Draconic is thought to be one of the oldest languages and is often used in the study of magic. The language sounds harsh to most other creatures and includes numerous hard consonants and sibilants."
+  },
+  "traits": [
+    {
+      "name": "Draconic Ancestry",
+      "description": "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table.",
+      "options_description": "CAPTION: Draconic Ancestry\n\nDragon Damage Type            Breath Weapon\nBlack  Acid            5 by 30 ft. line (Dex. save)\nBlue   Lightning       5 by 30 ft. line (Dex. save)\nBrass  Fire            5 by 30 ft. line (Dex. save)\nBronze Lightning       5 by 30 ft. line (Dex. save)\nCopper Acid            5 by 30 ft. line (Dex. save)\nGold   Fire            15 ft. cone (Dex. save)\nGreen  Poison          15 ft. cone (Con. save)\nRed    Fire            15 ft. cone (Dex. save)\nSilver Cold            15 ft. cone (Con. save)\nWhite  Cold            15 ft. cone (Con. save)",
+      "options": [
+        {
+          "dragon": "Black",
+          "damage_type": "Acid",
+          "breath_weapon_description": "5 by 30 ft. line (Dex. save)"
+        },
+        {
+          "dragon": "Blue",
+          "damage_type": "Lightning",
+          "breath_weapon_description": "5 by 30 ft. line (Dex. save)"
+        },
+        {
+          "dragon": "Brass",
+          "damage_type": "Fire",
+          "breath_weapon_description": "5 by 30 ft. line (Dex. save)"
+        },
+        {
+          "dragon": "Bronze",
+          "damage_type": "Lightning",
+          "breath_weapon_description": "5 by 30 ft. line (Dex. save)"
+        },
+        {
+          "dragon": "Copper",
+          "damage_type": "Acid",
+          "breath_weapon_description": "5 by 30 ft. line (Dex. save)"
+        },
+        {
+          "dragon": "Gold",
+          "damage_type": "Fire",
+          "breath_weapon_description": "15 ft. cone (Dex. save)"
+        },
+        {
+          "dragon": "Green",
+          "damage_type": "Poison",
+          "breath_weapon_description": "15 ft. cone (Con. save)"
+        },
+        {
+          "dragon": "Red",
+          "damage_type": "Fire",
+          "breath_weapon_description": "15 ft. cone (Dex. save)"
+        },
+        {
+          "dragon": "Silver",
+          "damage_type": "Cold",
+          "breath_weapon_description": "15 ft. cone (Con. save)"
+        },
+        {
+          "dragon": "White",
+          "damage_type": "Cold",
+          "breath_weapon_description": "15 ft. cone (Con. save)"
+        }
+      ]
+    },
+    {
+      "name": "Breath Weapon",
+      "description": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation.\n\nWhen you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level.\n\nAfter you use your breath weapon, you can’t use it again until you complete a short or long rest."
+    },
+    {
+      "name": "Damage Resistance",
+      "description": "You have resistance to the damage type associated with your draconic ancestry."
+    }
+  ]
+}

--- a/game_data/races/dwarf.json
+++ b/game_data/races/dwarf.json
@@ -1,0 +1,81 @@
+{
+  "name": "Dwarf",
+  "source": "Free Basic Rules (2014)",
+  "description": "Your dwarf character has an assortment of inborn abilities, part and parcel of dwarven nature.",
+  "ability_score_increase": {
+    "description": "Your Constitution score increases by 2.",
+    "abilities": [
+      {
+        "name": "Constitution",
+        "increase": 2
+      }
+    ]
+  },
+  "age": {
+    "description": "Dwarves mature at the same rate as humans, but they’re considered young until they reach the age of 50. On average, they live about 350 years."
+  },
+  "alignment": {
+    "description": "Most dwarves are lawful, believing firmly in the benefits of a well-ordered society. They tend toward good as well, with a strong sense of fair play and a belief that everyone deserves to share in the benefits of a just order."
+  },
+  "size": {
+    "name": "Medium",
+    "description": "Dwarves stand between 4 and 5 feet tall and average about 150 pounds. Your size is Medium."
+  },
+  "speed": {
+    "base": 25,
+    "description": "Your base walking speed is 25 feet. Your speed is not reduced by wearing heavy armor."
+  },
+  "languages": {
+    "chosen": [],
+    "options": [],
+    "static": [
+      "Common",
+      "Dwarvish"
+    ],
+    "description": "You can speak, read, and write Common and Dwarvish. Dwarvish is full of hard consonants and guttural sounds, and those characteristics spill over into whatever other language a dwarf might speak."
+  },
+  "traits": [
+    {
+      "name": "Darkvision",
+      "description": "Accustomed to life underground, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+    },
+    {
+      "name": "Dwarven Resilience",
+      "description": "You have advantage on saving throws against poison, and you have resistance against poison damage."
+    },
+    {
+      "name": "Dwarven Combat Training",
+      "description": "You have proficiency with the battleaxe, handaxe, light hammer, and warhammer."
+    },
+    {
+      "name": "Tool Proficiency",
+      "description": "You gain proficiency with the artisan’s tools of your choice: smith’s tools, brewer’s supplies, or mason’s tools."
+    },
+    {
+      "name": "Stonecunning",
+      "description": "Whenever you make an Intelligence (History) check related to the origin of stonework, you are considered proficient in the History skill and add double your proficiency bonus to the check, instead of your normal proficiency bonus."
+    }
+  ],
+  "subraces": [
+    {
+      "name": "Hill Dwarf",
+      "source": "Free Basic Rules (2014)",
+      "description": "As a hill dwarf, you have keen senses, deep intuition, and remarkable resilience.",
+      "ability_score_increase": {
+        "description": "Your Wisdom score increases by 1.",
+        "abilities": [
+          {
+            "name": "Wisdom",
+            "increase": 1
+          }
+        ]
+      },
+      "traits": [
+        {
+          "name": "Dwarven Toughness",
+          "description": "Your hit point maximum increases by 1, and it increases by 1 every time you gain a level."
+        }
+      ]
+    }
+  ]
+}

--- a/game_data/races/elf.json
+++ b/game_data/races/elf.json
@@ -1,0 +1,85 @@
+{
+  "name": "Elf",
+  "source": "Free Basic Rules (2014)",
+  "description": "Your elf character has a variety of natural abilities, the result of thousands of years of elven refinement.",
+  "ability_score_increase": {
+    "description": "Your Dexterity score increases by 2.",
+    "abilities": [
+      {
+        "name": "Dexterity",
+        "increase": 2
+      }
+    ]
+  },
+  "age": {
+    "description": "Although elves reach physical maturity at about the same age as humans, the elven understanding of adulthood goes beyond physical growth to encompass worldly experience. An elf typically claims adulthood and an adult name around the age of 100 and can live to be 750 years old."
+  },
+  "alignment": {
+    "description": "Elves love freedom, variety, and self- expression, so they lean strongly toward the gentler aspects of chaos. They value and protect others’ freedom as well as their own, and they are more often good than not."
+  },
+  "size": {
+    "name": "Medium",
+    "description": "Elves range from under 5 to over 6 feet tall and have slender builds. Your size is Medium."
+  },
+  "speed": {
+    "base": 30,
+    "description": "Your base walking speed is 30 feet."
+  },
+  "languages": {
+    "chosen": [],
+    "options": [],
+    "static": [
+      "Common",
+      "Elvish"
+    ],
+    "description": "You can speak, read, and write Common and Elvish. Elvish is fluid, with subtle intonations and intricate grammar. Elven literature is rich and varied, and their songs and poems are famous among other races. Many bards learn their language so they can add Elvish ballads to their repertoires."
+  },
+  "traits": [
+    {
+      "name": "Darkvision",
+      "description": "Accustomed to twilit forests and the night sky, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+    },
+    {
+      "name": "Keen Senses",
+      "description": "You have proficiency in the Perception skill."
+    },
+    {
+      "name": "Fey Ancestry",
+      "description": "You have advantage on saving throws against being charmed, and magic can’t put you to sleep."
+    },
+    {
+      "name": "Trance",
+      "description": "Elves don’t need to sleep. Instead, they meditate deeply, remaining semiconscious, for 4 hours a day. (The Common word for such meditation is “trance.”) While meditating, you can dream after a fashion; such dreams are actually mental exercises that have become reflexive through years of practice. After resting in this way, you gain the same benefit that a human does from 8 hours of sleep."
+    }
+  ],
+  "subraces": [
+    {
+      "name": "High Elf",
+      "source": "Free Basic Rules (2014)",
+      "description": "As a high elf, you have a keen mind and a mastery of at least the basics of magic. In many fantasy gaming worlds, there are two kinds of high elves. One type is haughty and reclusive, believing themselves to be superior to non-elves and even other elves. The other type is more common and more friendly, and often encountered among humans and other races.",
+      "ability_score_increase": {
+        "description": "Your Intelligence score increases by 1.",
+        "abilities": [
+          {
+            "name": "Intelligence",
+            "increase": 1
+          }
+        ]
+      },
+      "traits": [
+        {
+          "name": "Elf Weapon Training",
+          "description": "You have proficiency with the longsword, shortsword, shortbow, and longbow."
+        },
+        {
+          "name": "Cantrip",
+          "description": "You know one cantrip of your choice from the wizard spell list. Intelligence is your spellcasting ability for it."
+        },
+        {
+          "name": "Extra Language",
+          "description": "You can speak, read, and write one extra language of your choice."
+        }
+      ]
+    }
+  ]
+}

--- a/game_data/races/firbolg.json
+++ b/game_data/races/firbolg.json
@@ -1,0 +1,111 @@
+{
+  "name": "Firbolg",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/firbolg",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Firbolg Magic",
+          "description": "You can cast the Detect Magic and Disguise Self spells with this trait. When you use this version of Disguise Self, you can seem up to 3 feet shorter or taller. Once you cast either of these spells with this trait, you can’t cast that spell with it again until you finish a long rest. You can also cast these spells using any spell slots you have.\nIntelligence, Wisdom, or Charisma is your spellcasting ability for these spells when you cast them with this trait (choose when you select this race)."
+        },
+        {
+          "name": "Hidden Step",
+          "description": "As a bonus action, you can magically turn invisible until the start of your next turn or until you attack, make a damage roll, or force someone to make a saving throw. You can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+        },
+        {
+          "name": "Powerful Build",
+          "description": "You count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+        },
+        {
+          "name": "Speech of Beast and Leaf",
+          "description": "You have the ability to communicate in a limited manner with Beasts, Plants, and vegetation. They can understand the meaning of your words, though you have no special ability to understand them in return. You have advantage on all Charisma checks you make to influence them."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Volo's Guide",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/firbolg",
+      "ability_score_increase": [
+        {
+          "ability": "Wisdom",
+          "increase": 2
+        },
+        {
+          "ability": "Strength",
+          "increase": 1
+        }
+      ],
+      "size": "Medium (7-8 feet tall)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Firbolg Magic",
+          "description": "You can cast Detect Magic and Disguise Self with this trait, using Wisdom as your spellcasting ability for them. Once you cast either spell, you can't cast it again with this trait until you finish a short or long rest. When you use this version of disguise self, you can seem up to 3 feet shorter than normal, allowing you to more easily blend in with humans and elves."
+        },
+        {
+          "name": "Hidden Step",
+          "description": "As a bonus action, you can magically turn invisible until the start of your next turn or until you attack, make a damage roll, or force someone to make a saving throw. Once you use this trait, you can't use it again until you finish a short or long rest."
+        },
+        {
+          "name": "Powerful Build",
+          "description": "You count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+        },
+        {
+          "name": "Speech of Beast and Leaf",
+          "description": "You have the ability to communicate in a limited manner with beasts and plants. They can understand the meaning of your words, though you have no special ability to understand them in return. You have advantage on all Charisma checks you make to influence them."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Elvish",
+          "Giant"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/genasi_air.json
+++ b/game_data/races/genasi_air.json
@@ -1,0 +1,102 @@
+{
+  "name": "Air Genasi",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-air",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 35
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Unending Breath",
+          "description": "You can hold your breath indefinitely while you’re not incapacitated."
+        },
+        {
+          "name": "Lightning Resistance",
+          "description": "You have resistance to lightning damage."
+        },
+        {
+          "name": "Mingle with the Wind",
+          "description": "You know the Shocking Grasp cantrip. Starting at 3rd level, you can cast the Feather Fall spell with this trait, without requiring a material component. Starting at 5th level, you can also cast the Levitate spell with this trait, without requiring a material component. Once you cast Feather Fall or Levitate with this trait, you can’t cast that spell with it again until you finish a long rest. You can also cast either of those spells using any spell slots you have of the appropriate level.\nIntelligence, Wisdom, or Charisma is your spellcasting ability for these spells when you cast them with this trait (choose when you select this race)."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Elemental Evil Player's Companion",
+      "source": "Elemental Evil Player's Companion",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-air",
+      "ability_score_increase": [
+        {
+          "ability": "Constitution",
+          "increase": 2
+        },
+        {
+          "ability": "Dexterity",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Unending Breath",
+          "description": "You can hold your breath indefinitely while you’re not incapacitated."
+        },
+        {
+          "name": "Mingle with the Wind",
+          "description": "You can cast the Levitate spell once with this trait, requiring no material components, and you regain the ability to cast it this way when you finish a long rest. Constitution is your spellcasting ability for this spell."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Primordial"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/genasi_earth.json
+++ b/game_data/races/genasi_earth.json
@@ -1,0 +1,98 @@
+{
+  "name": "Earth Genasi",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-earth",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Earth Walk",
+          "description": "You can move across difficult terrain without expending extra movement if you are using your walking speed on the ground or a floor."
+        },
+        {
+          "name": "Merge with Stone",
+          "description": "You know the Blade Ward cantrip. You can cast it as normal, and you can also cast it as a bonus action a number of times equal to your proficiency bonus, regaining all expended uses when you finish a long rest.\nStarting at 5th level, you can cast the Pass Without Trace spell with this trait, without requiring a material component. Once you cast that spell with this trait, you can’t do so again until you finish a long rest. You can also cast it using any spell slots you have of 2nd level or higher.\nIntelligence, Wisdom, or Charisma is your spellcasting ability for these spells when you cast them with this trait (choose when you select this race)."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Elemental Evil Player's Companion",
+      "source": "Elemental Evil Player's Companion",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-earth",
+      "ability_score_increase": [
+        {
+          "ability": "Constitution",
+          "increase": 2
+        },
+        {
+          "ability": "Strength",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Earth Walk",
+          "description": "You can move across difficult terrain made of earth or stone without expending extra movement."
+        },
+        {
+          "name": "Merge with Stone",
+          "description": "You can cast the Pass without Trace spell once with this trait, requiring no material components, and you regain the ability to cast it this way when you finish a long rest. Constitution is your spellcasting ability for this spell."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Primordial"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/genasi_fire.json
+++ b/game_data/races/genasi_fire.json
@@ -1,0 +1,102 @@
+{
+  "name": "Fire Genasi",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-fire",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Fire Resistance",
+          "description": "You have resistance to fire damage."
+        },
+        {
+          "name": "Reach to the Blaze",
+          "description": "You know the Produce Flame cantrip. Starting at 3rd level, you can cast the Burning Hands spell with this trait. Starting at 5th level, you can also cast the Flame Blade spell with this trait, without requiring a material component. Once you cast Burning Hands or Flame Blade with this trait, you can’t cast that spell with it again until you finish a long rest. You can also cast either of those spells using any spell slots you have of the appropriate level.\nIntelligence, Wisdom, or Charisma is your spellcasting ability for these spells when you cast them with this trait (choose when you select this race)."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Elemental Evil Player's Companion",
+      "source": "Elemental Evil Player's Companion",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-fire",
+      "ability_score_increase": [
+        {
+          "ability": "Constitution",
+          "increase": 2
+        },
+        {
+          "ability": "Intelligence",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. Your ties to the Elemental Plane of Fire make your darkvision unusual: everything you see in darkness is in a shade of red."
+        },
+        {
+          "name": "Fire Resistance",
+          "description": "You have resistance to fire damage."
+        },
+        {
+          "name": "Reach to the Blaze",
+          "description": "You know the Produce Flame cantrip. Once you reach 3rd level, you can cast the Burning Hands spell once with this trait as a 1st-level spell, and you regain the ability to cast it this way when you finish a long rest. Constitution is your spellcasting ability for these spells."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Primordial"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/genasi_water.json
+++ b/game_data/races/genasi_water.json
@@ -1,0 +1,104 @@
+{
+  "name": "Water Genasi",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-water",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 30,
+        "swim": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Acid Resistance",
+          "description": "You have resistance to acid damage."
+        },
+        {
+          "name": "Amphibious",
+          "description": "You can breathe air and water."
+        },
+        {
+          "name": "Call to the Wave",
+          "description": "You know the Acid Splash cantrip. Starting at 3rd level, you can cast the Create or Destroy Water spell with this trait. Starting at 5th level, you can also cast the Water Walk spell with this trait, without requiring a material component. Once you cast Create or Destroy Water or Water Walk with this trait, you can’t cast that spell with it again until you finish a long rest. You can also cast either of those spells using any spell slots you have of the appropriate level.\nIntelligence, Wisdom, or Charisma is your spellcasting ability for these spells when you cast them with this trait (choose when you select this race)."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Elemental Evil Player's Companion",
+      "source": "Elemental Evil Player's Companion",
+      "source_url": "http://dnd5e.wikidot.com/lineage:genasi-water",
+      "ability_score_increase": [
+        {
+          "ability": "Wisdom",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30,
+        "swim": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Acid Resistance",
+          "description": "You have resistance to acid damage."
+        },
+        {
+          "name": "Amphibious",
+          "description": "You can breathe air and water."
+        },
+        {
+          "name": "Call to the Wave",
+          "description": "You know the Shape Water cantrip. When you reach 3rd level, you can cast the Create or Destroy Water spell as a 2nd-level spell once with this trait, and you regain the ability to cast it this way when you finish a long rest. Constitution is your spellcasting ability for these spells."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Primordial"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/gnome.json
+++ b/game_data/races/gnome.json
@@ -1,0 +1,88 @@
+{
+  "name": "Gnome",
+  "source": "Free Basic Rules (2014)",
+  "description": "Your gnome character has certain characteristics in common with all other gnomes.",
+  "ability_score_increase": {
+    "description": "Your Intelligence score increases by 2.",
+    "abilities": [
+      {
+        "name": "Intelligence",
+        "increase": 2
+      }
+    ]
+  },
+  "age": {
+    "description": "Gnomes mature at the same rate humans do, and most are expected to settle down into an adult life by around age 40. They can live 350 to almost 500 years."
+  },
+  "alignment": {
+    "description": "Gnomes are most often good. Those who tend toward law are sages, engineers, researchers, scholars, investigators, or inventors. Those who tend toward chaos are minstrels, tricksters, wanderers, or fanciful jewelers. Gnomes are good-hearted, and even the tricksters among them are more playful than vicious."
+  },
+  "size": {
+    "name": "Small",
+    "description": "Gnomes are between 3 and 4 feet tall and average about 40 pounds. Your size is Small."
+  },
+  "speed": {
+    "base": 25,
+    "description": "Your base walking speed is 25 feet."
+  },
+  "languages": {
+    "chosen": [],
+    "options": [],
+    "static": [
+      "Common",
+      "Gnomish"
+    ],
+    "description": "You can speak, read, and write Common and Gnomish. The Gnomish language, which uses the Dwarvish script, is renowned for its technical treatises and its catalogs of knowledge about the natural world."
+  },
+  "traits": [
+    {
+      "name": "Darkvision",
+      "description": "Accustomed to life underground, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+    },
+    {
+      "name": "Gnome Cunning",
+      "description": "You have advantage on all Intelligence, Wisdom, and Charisma saving throws against magic."
+    }
+  ],
+  "subraces": [
+    {
+      "name": "Rock Gnome",
+      "source": "Free Basic Rules (2014)",
+      "description": "As a rock gnome, you have a natural inventiveness and hardiness beyond that of other gnomes.",
+      "ability_score_increase": {
+        "description": "Your Constitution score increases by 1.",
+        "abilities": [
+          {
+            "name": "Constitution",
+            "increase": 1
+          }
+        ]
+      },
+      "traits": [
+        {
+          "name": "Artificer's Lore",
+          "description": "Whenever you make an Intelligence (History) check related to magic items, alchemical objects, or technological devices, you can add twice your proficiency bonus, instead of any proficiency bonus you normally apply."
+        },
+        {
+          "name": "Tinker",
+          "description": "You have proficiency with artisan’s tools (tinker’s tools). Using those tools, you can spend 1 hour and 10 gp worth of materials to construct a Tiny clockwork device (AC 5, 1 hp). The device ceases to function after 24 hours (unless you spend 1 hour repairing it to keep the device functioning), or when you use your action to dismantle it; at that time, you can reclaim the materials used to create it. You can have up to three such devices active at a time. When you create a device, choose one of the following options:",
+          "options_description": "// TODO: Parse the following options into a structured list if possible, for now it's a single string.\nClockwork Toy: This toy is a clockwork animal, monster, or person, such as a frog, mouse, bird, dragon, or soldier. When placed on the ground, the toy moves 5 feet across the ground on each of your turns in a random direction. It makes noises as appropriate to the creature it represents.\nFire Starter: The device produces a miniature flame, which you can use to light a candle, torch, or campfire. Using the device requires your action.\nMusic Box: When opened, this music box plays a single song at a moderate volume. The box stops playing when it reaches the song’s end or when it is closed.",
+          "options": [
+            {
+              "name": "Clockwork Toy",
+              "description": "This toy is a clockwork animal, monster, or person, such as a frog, mouse, bird, dragon, or soldier. When placed on the ground, the toy moves 5 feet across the ground on each of your turns in a random direction. It makes noises as appropriate to the creature it represents."
+            },
+            {
+              "name": "Fire Starter",
+              "description": "The device produces a miniature flame, which you can use to light a candle, torch, or campfire. Using the device requires your action."
+            },
+            {
+              "name": "Music Box",
+              "description": "When opened, this music box plays a single song at a moderate volume. The box stops playing when it reaches the song’s end or when it is closed."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/game_data/races/goliath.json
+++ b/game_data/races/goliath.json
@@ -1,0 +1,106 @@
+{
+  "name": "Goliath",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/goliath",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium (7-8 feet tall)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Little Giant",
+          "description": "You have proficiency in the Athletics skill, and you count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+        },
+        {
+          "name": "Mountain Born",
+          "description": "You have resistance to cold damage. You also naturally acclimate to high altitudes, even if you’ve never been to one. This includes elevations above 20,000 feet."
+        },
+        {
+          "name": "Stone's Endurance",
+          "description": "You can supernaturally draw on unyielding stone to shrug off harm. When you take damage, you can use your reaction to roll a d12. Add your Constitution modifier to the number rolled and reduce the damage by that total.\nYou can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Elemental Evil Player's Companion",
+      "source": "Elemental Evil Player's Guide",
+      "source_url": "http://dnd5e.wikidot.com/goliath",
+      "ability_score_increase": [
+        {
+          "ability": "Strength",
+          "increase": 2
+        },
+        {
+          "ability": "Constitution",
+          "increase": 1
+        }
+      ],
+      "size": "Medium (7-8 feet tall)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Natural Athlete",
+          "description": "You have proficiency in the Athletics skill."
+        },
+        {
+          "name": "Stone's Endurance",
+          "description": "You can focus yourself to occasionally shrug off injury. When you take damage, you can use your reaction to roll a d12. Add your Constitution modifier to the number rolled, and reduce the damage by that total. After you use this trait, you can’t use it again until you finish a short or long rest."
+        },
+        {
+          "name": "Powerful Build",
+          "description": "You count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+        },
+        {
+          "name": "Mountain Born",
+          "description": "You have resistance to cold damage. You’re also acclimated to high altitude, including elevations above 20,000 feet."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Giant"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/half_elf.json
+++ b/game_data/races/half_elf.json
@@ -1,0 +1,69 @@
+{
+  "name": "Half-Elf",
+  "source": "Free Basic Rules (2014)",
+  "description": "Your half-elf character has some qualities in common with elves and some that are unique to half-elves.",
+  "ability_score_increase": {
+    "description": "Your Charisma score increases by 2, and two other ability scores of your choice increase by 1.",
+    "abilities": [
+      {
+        "name": "Charisma",
+        "increase": 2
+      }
+    ],
+    "choose": {
+      "count": 2,
+      "from": [
+        "Strength",
+        "Dexterity",
+        "Constitution",
+        "Intelligence",
+        "Wisdom"
+      ],
+      "increase": 1
+    }
+  },
+  "age": {
+    "description": "Half-elves mature at the same rate humans do and reach adulthood around the age of 20. They live much longer than humans, however, often exceeding 180 years."
+  },
+  "alignment": {
+    "description": "Half-elves share the chaotic bent of their elven heritage. They value both personal freedom and creative expression, demonstrating neither love of leaders nor desire for followers. They chafe at rules, resent others’ demands, and sometimes prove unreliable, or at least unpredictable."
+  },
+  "size": {
+    "name": "Medium",
+    "description": "Half-elves are about the same size as humans, ranging from 5 to 6 feet tall. Your size is Medium."
+  },
+  "speed": {
+    "base": 30,
+    "description": "Your base walking speed is 30 feet."
+  },
+  "languages": {
+    "static": [
+      "Common",
+      "Elvish"
+    ],
+    "choose": {
+      "count": 1,
+      "from": "any standard language"
+    },
+    "description": "You can speak, read, and write Common, Elvish, and one extra language of your choice."
+  },
+  "traits": [
+    {
+      "name": "Darkvision",
+      "description": "Thanks to your elf blood, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+    },
+    {
+      "name": "Fey Ancestry",
+      "description": "You have advantage on saving throws against being charmed, and magic can’t put you to sleep."
+    },
+    {
+      "name": "Skill Versatility",
+      "description": "You gain proficiency in two skills of your choice.",
+      "choose": {
+        "count": 2,
+        "from": "any skill"
+      }
+    }
+  ],
+  "subraces": []
+}

--- a/game_data/races/half_orc.json
+++ b/game_data/races/half_orc.json
@@ -1,0 +1,58 @@
+{
+  "name": "Half-Orc",
+  "source": "Free Basic Rules (2014)",
+  "description": "Your half-orc character has certain traits deriving from your orc ancestry.",
+  "ability_score_increase": {
+    "description": "Your Strength score increases by 2, and your Constitution score increases by 1.",
+    "abilities": [
+      {
+        "name": "Strength",
+        "increase": 2
+      },
+      {
+        "name": "Constitution",
+        "increase": 1
+      }
+    ]
+  },
+  "age": {
+    "description": "Half-orcs mature a little faster than humans, reaching adulthood around age 14. They age noticeably faster and rarely live longer than 75 years."
+  },
+  "alignment": {
+    "description": "Half-orcs inherit a tendency toward chaos from their orc parents and are not strongly inclined toward good. Half-orcs raised among orcs and willing to live out their lives among them are usually evil."
+  },
+  "size": {
+    "name": "Medium",
+    "description": "Half-orcs are somewhat larger and bulkier than humans, and they range from 5 to well over 6 feet tall. Your size is Medium."
+  },
+  "speed": {
+    "base": 30,
+    "description": "Your base walking speed is 30 feet."
+  },
+  "languages": {
+    "static": [
+      "Common",
+      "Orc"
+    ],
+    "description": "You can speak, read, and write Common and Orc. Orc is a harsh, grating language with hard consonants. It has no script of its own but is written in the Dwarvish script."
+  },
+  "traits": [
+    {
+      "name": "Darkvision",
+      "description": "Thanks to your orc blood, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+    },
+    {
+      "name": "Menacing",
+      "description": "You gain proficiency in the Intimidation skill."
+    },
+    {
+      "name": "Relentless Endurance",
+      "description": "When you are reduced to 0 hit points but not killed outright, you can drop to 1 hit point instead. You can’t use this feature again until you finish a long rest."
+    },
+    {
+      "name": "Savage Attacks",
+      "description": "When you score a critical hit with a melee weapon attack, you can roll one of the weapon’s damage dice one additional time and add it to the extra damage of the critical hit."
+    }
+  ],
+  "subraces": []
+}

--- a/game_data/races/halfling.json
+++ b/game_data/races/halfling.json
@@ -1,0 +1,71 @@
+{
+  "name": "Halfling",
+  "source": "Free Basic Rules (2014)",
+  "description": "Your halfling character has a number of traits in common with all other halflings.",
+  "ability_score_increase": {
+    "description": "Your Dexterity score increases by 2.",
+    "abilities": [
+      {
+        "name": "Dexterity",
+        "increase": 2
+      }
+    ]
+  },
+  "age": {
+    "description": "A halfling reaches adulthood at the age of 20 and generally lives into the middle of his or her second century."
+  },
+  "alignment": {
+    "description": "Most halflings are lawful good. As a rule, they are good-hearted and kind, hate to see others in pain, and have no tolerance for oppression. They are also very orderly and traditional, leaning heavily on the support of their community and the comfort of their old ways."
+  },
+  "size": {
+    "name": "Small",
+    "description": "Halflings average about 3 feet tall and weigh about 40 pounds. Your size is Small."
+  },
+  "speed": {
+    "base": 25,
+    "description": "Your base walking speed is 25 feet."
+  },
+  "languages": {
+    "static": [
+      "Common",
+      "Halfling"
+    ],
+    "description": "You can speak, read, and write Common and Halfling. The Halfling language isn’t secret, but halflings are loath to share it with others. They write very little, so they don’t have a rich body of literature. Their oral tradition, however, is very strong. Almost all halflings speak Common to converse with the people in whose lands they dwell or through which they are traveling."
+  },
+  "traits": [
+    {
+      "name": "Lucky",
+      "description": "When you roll a 1 on the d20 for an attack roll, ability check, or saving throw, you can reroll the die and must use the new roll."
+    },
+    {
+      "name": "Brave",
+      "description": "You have advantage on saving throws against being frightened."
+    },
+    {
+      "name": "Halfling Nimbleness",
+      "description": "You can move through the space of any creature that is of a size larger than yours."
+    }
+  ],
+  "subraces": [
+    {
+      "name": "Lightfoot Halfling",
+      "source": "Free Basic Rules (2014)",
+      "description": "As a lightfoot halfling, you can easily hide from notice, even using other people as cover. You’re inclined to be affable and get along well with others.\nLightfoots are more prone to wanderlust than other halflings, and often dwell alongside other races or take up a nomadic life.",
+      "ability_score_increase": {
+        "description": "Your Charisma score increases by 1.",
+        "abilities": [
+          {
+            "name": "Charisma",
+            "increase": 1
+          }
+        ]
+      },
+      "traits": [
+        {
+          "name": "Naturally Stealthy",
+          "description": "You can attempt to hide even when you are obscured only by a creature that is at least one size larger than you."
+        }
+      ]
+    }
+  ]
+}

--- a/game_data/races/human.json
+++ b/game_data/races/human.json
@@ -1,0 +1,60 @@
+{
+  "name": "Human",
+  "source": "Free Basic Rules (2014)",
+  "description": "It’s hard to make generalizations about humans, but your human character has these traits.",
+  "ability_score_increase": {
+    "description": "Your ability scores each increase by 1.",
+    "abilities": [
+      {
+        "name": "Strength",
+        "increase": 1
+      },
+      {
+        "name": "Dexterity",
+        "increase": 1
+      },
+      {
+        "name": "Constitution",
+        "increase": 1
+      },
+      {
+        "name": "Intelligence",
+        "increase": 1
+      },
+      {
+        "name": "Wisdom",
+        "increase": 1
+      },
+      {
+        "name": "Charisma",
+        "increase": 1
+      }
+    ]
+  },
+  "age": {
+    "description": "Humans reach adulthood in their late teens and live less than a century."
+  },
+  "alignment": {
+    "description": "Humans tend toward no particular alignment. The best and the worst are found among them."
+  },
+  "size": {
+    "name": "Medium",
+    "description": "Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium."
+  },
+  "speed": {
+    "base": 30,
+    "description": "Your base walking speed is 30 feet."
+  },
+  "languages": {
+    "static": [
+      "Common"
+    ],
+    "choose": {
+      "count": 1,
+      "from": "any standard language"
+    },
+    "description": "You can speak, read, and write Common and one extra language of your choice. Humans typically learn the languages of other peoples they deal with, including obscure dialects. They are fond of sprinkling their speech with words borrowed from other tongues: Orc curses, Elvish musical expressions, Dwarvish military phrases, and so on."
+  },
+  "traits": [],
+  "subraces": []
+}

--- a/game_data/races/kalashtar_erlw.json
+++ b/game_data/races/kalashtar_erlw.json
@@ -1,0 +1,51 @@
+{
+  "name": "Kalashtar",
+  "variants": [
+    {
+      "version_name": "Eberron - Rising from the Last War",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/kalashtar",
+      "ability_score_increase": [
+        {
+          "ability": "Wisdom",
+          "increase": 2
+        },
+        {
+          "ability": "Charisma",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Dual Mind",
+          "description": "You have advantage on all Wisdom saving throws."
+        },
+        {
+          "name": "Mental Discipline",
+          "description": "You have resistance to psychic damage."
+        },
+        {
+          "name": "Mind Link",
+          "description": "You can speak telepathically to any creature you can see, provided the creature is within a number of feet of you equal to 10 times your level. You don't need to share a language with the creature for it to understand your telepathic utterances, but the creature must be able to understand at least one language.\nWhen you're using this trait to speak telepathically to a creature, you can use your action to give that creature the ability to speak telepathically with you for 1 hour or until you end this effect as an action. To use this ability, the creature must be able to see you and must be within this trait's range. You can give this ability to only one creature at a time; giving it to a creature takes it away from another creature who has it."
+        },
+        {
+          "name": "Severed from Dreams",
+          "description": "Kalashtar sleep, but they don’t connect to the plane of dreams as other creatures do. Instead, their minds draw from the memories of their otherworldly spirit while they sleep. As such, you are immune to magical spells and effects that require you to dream, like the Dream spell, but not to spells and effects that put you to sleep, like the Sleep spell."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Quori"
+        ],
+        "choose": 1,
+        "options_description": "one other language of your choice."
+      }
+    }
+  ]
+}

--- a/game_data/races/kenku.json
+++ b/game_data/races/kenku.json
@@ -1,0 +1,102 @@
+{
+  "name": "Kenku",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/kenku",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Expert Duplication",
+          "description": "When you copy writing or craftwork produced by yourself or someone else, you have advantage on any ability checks you make to produce an exact duplicate."
+        },
+        {
+          "name": "Kenku Recall",
+          "description": "Thanks to your supernaturally good memory, you have proficiency in two skills of your choice.\nMoreover, when you make an ability check using any skill in which you have proficiency, you can give yourself advantage on the check before rolling the d20. You can give yourself advantage in this way a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+        },
+        {
+          "name": "Mimicry",
+          "description": "You can accurately mimic sounds you have heard, including voices. A creature that hears the sounds you make can tell they are imitations only with a successful Wisdom (Insight) check against a DC of 8 + your proficiency bonus + your Charisma modifier."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Volo's Guide",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/kenku",
+      "ability_score_increase": [
+        {
+          "ability": "Dexterity",
+          "increase": 2
+        },
+        {
+          "ability": "Wisdom",
+          "increase": 1
+        }
+      ],
+      "size": "Medium (~5 feet tall)",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Expert Forgery",
+          "description": "You can duplicate other creatures' handwriting and craftwork. You have advantage on all checks made to produce forgeries or duplicates of existing objects."
+        },
+        {
+          "name": "Kenku Training",
+          "description": "You are proficient in your choice of two of the following skills: Acrobatics, Deception, Stealth, and Sleight of Hand."
+        },
+        {
+          "name": "Mimicry",
+          "description": "You can mimic sounds you have heard, including voices. A creature that hears the sounds you make can tell they are imitations with a successful Wisdom (Insight) check opposed by your Charisma (Deception) check."
+        }
+      ],
+      "languages": {
+        "known": [],
+        "can_read_write": ["Common", "Auran"],
+        "can_speak": "only by using Mimicry trait",
+        "description": "You can read and write Common and Auran, but you can speak only by using your Mimicry trait."
+      }
+    }
+  ]
+}

--- a/game_data/races/lizardfolk.json
+++ b/game_data/races/lizardfolk.json
@@ -1,0 +1,124 @@
+{
+  "name": "Lizardfolk",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/lizardfolk",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30,
+        "swim": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Bite",
+          "description": "You have a fanged maw that you can use to make unarmed strikes. When you hit with it, the strike deals 1d6 + your Strength modifier slashing damage, instead of the bludgeoning damage normal for an unarmed strike."
+        },
+        {
+          "name": "Hold Breath",
+          "description": "You can hold your breath for up to 15 minutes at a time."
+        },
+        {
+          "name": "Hungry Jaws",
+          "description": "You can throw yourself into a feeding frenzy. As a bonus action, you can make a special attack with your Bite. If the attack hits, it deals its normal damage, and you gain temporary hit points equal to your proficiency bonus. You can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+        },
+        {
+          "name": "Natural Armor",
+          "description": "You have tough, scaly skin. When you aren’t wearing armor, your base AC is 13 + your Dexterity modifier. You can use your natural armor to determine your AC if the armor you wear would leave you with a lower AC. A shield’s benefits apply as normal while you use your natural armor."
+        },
+        {
+          "name": "Nature's Intuition",
+          "description": "Thanks to your mystical connection to nature, you gain proficiency with two of the following skills of your choice: Animal Handling, Medicine, Nature, Perception, Stealth, or Survival."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Volo's Guide",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/lizardfolk",
+      "ability_score_increase": [
+        {
+          "ability": "Constitution",
+          "increase": 2
+        },
+        {
+          "ability": "Wisdom",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30,
+        "swim": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Bite",
+          "description": "Your fanged maw is a natural weapon, which you can use to make unarmed strikes. If you hit with it, you deal piercing damage equal to 1d6 + your Strength modifier, instead of the bludgeoning damage normal for an unarmed strike."
+        },
+        {
+          "name": "Cunning Artisan",
+          "description": "As part of a short rest, you can harvest bone and hide from a slain beast, construct, dragon, monstrosity, or plant creature of size Small or larger to create one of the following items: a shield, a club, a javelin, or 1d4 darts or blowgun needles. To use this trait, you need a blade, such as a dagger, or appropriate artisan's tools, such as leatherworker's tools."
+        },
+        {
+          "name": "Hold Breath",
+          "description": "You can hold your breath for up to 15 minutes at a time."
+        },
+        {
+          "name": "Hunter's Lore",
+          "description": "You gain proficiency with two of the following skills of your choice: Animal Handling, Nature, Perception, Stealth, and Survival."
+        },
+        {
+          "name": "Natural Armor",
+          "description": "You have tough, scaly skin. When you aren't wearing armor, your AC is 13 + your Dexterity modifier. You can use your natural armor to determine your AC if the armor you wear would leave you with a lower AC. A shield's benefits apply as normal while you use your natural armor."
+        },
+        {
+          "name": "Hungry Jaws",
+          "description": "In battle, you can throw yourself into a vicious feeding frenzy. As a bonus action, you can make a special attack with your bite. If the attack hits, it deals its normal damage, and you gain temporary hit points (minimum of 1) equal to your Constitution modifier, and you can't use this trait again until you finish a short or long rest."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Draconic"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/orc.json
+++ b/game_data/races/orc.json
@@ -1,0 +1,154 @@
+{
+  "name": "Orc",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/orc",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Adrenaline Rush",
+          "description": "You can take the Dash action as a bonus action. You can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.\nWhenever you use this trait, you gain a number of temporary hit points equal to your proficiency bonus."
+        },
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Powerful Build",
+          "description": "You count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+        },
+        {
+          "name": "Relentless Endurance",
+          "description": "When you are reduced to 0 hit points but not killed outright, you can drop to 1 hit point instead. Once you use this trait, you can’t do so again until you finish a long rest."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Eberron - Rising from the Last War",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/orc",
+      "ability_score_increase": [
+        {
+          "ability": "Strength",
+          "increase": 2
+        },
+        {
+          "ability": "Constitution",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Aggressive",
+          "description": "As a bonus action, you can move up to your speed toward an enemy of your choice that you can see or hear. You must end this move closer to the enemy than you started."
+        },
+        {
+          "name": "Powerful Build",
+          "description": "You count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+        },
+        {
+          "name": "Primal Intuition",
+          "description": "You have proficiency in two of the following skills of your choice: Animal Handling, Insight, Intimidation, Medicine, Nature, Perception, and Survival."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Orc"
+        ]
+      }
+    },
+    {
+      "version_name": "Volo's Guide",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/orc",
+      "ability_score_increase": [
+        {
+          "ability": "Strength",
+          "increase": 2
+        },
+        {
+          "ability": "Constitution",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Aggressive",
+          "description": "As a bonus action, you can move up to your speed toward an enemy of your choice that you can see or hear. You must end this move closer to the enemy than you started."
+        },
+        {
+          "name": "Primal Intuition",
+          "description": "You have proficiency in two of the following skills of your choice: Animal Handling, Insight, Intimidation, Medicine, Nature, Perception, and Survival."
+        },
+        {
+          "name": "Powerful Build",
+          "description": "You count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Orc"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/shifter.json
+++ b/game_data/races/shifter.json
@@ -1,0 +1,269 @@
+{
+  "name": "Shifter",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/shifter",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Bestial Instincts",
+          "description": "Channeling the beast within, you have proficiency in one of the following skills of your choice: Acrobatics, Athletics, Intimidation, or Survival."
+        },
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Shifting",
+          "description": "As a bonus action, you can assume a more bestial appearance. This transformation lasts for 1 minute, until you die, or until you revert to your normal appearance as a bonus action. When you shift, you gain temporary hit points equal to 2 x your proficiency bonus. You can shift a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest.\nWhenever you shift, you gain an additional benefit based on one of the following options (choose when you select this race):",
+          "options_description": "// TODO: Parse the following options into a structured list if possible, for now it's a single string.\nBeasthide. You gain 1d6 additional temporary hit points. While shifted, you have a +1 bonus to your Armor Class.\nLongtooth. When you shift and as a bonus action on your other turns while shifted, you can use your elongated fangs to make an unarmed strike. If you hit with your fangs, you can deal piercing damage equal to 1d6 + your Strength modifier, instead of the bludgeoning damage normal for an unarmed strike.\nSwiftstride. While shifted, your walking speed increases by 10 feet. Additionally, you can move up to 10 feet as a reaction when a creature ends its turn within 5 feet of you. This reactive movement doesn’t provoke opportunity attacks.\nWildhunt. While shifted, you have advantage on Wisdom checks, and no creature within 30 feet of you can make an attack roll with advantage against you unless you’re incapacitated.",
+          "options": [
+            {
+              "name": "Beasthide",
+              "description": "You gain 1d6 additional temporary hit points. While shifted, you have a +1 bonus to your Armor Class."
+            },
+            {
+              "name": "Longtooth",
+              "description": "When you shift and as a bonus action on your other turns while shifted, you can use your elongated fangs to make an unarmed strike. If you hit with your fangs, you can deal piercing damage equal to 1d6 + your Strength modifier, instead of the bludgeoning damage normal for an unarmed strike."
+            },
+            {
+              "name": "Swiftstride",
+              "description": "While shifted, your walking speed increases by 10 feet. Additionally, you can move up to 10 feet as a reaction when a creature ends its turn within 5 feet of you. This reactive movement doesn’t provoke opportunity attacks."
+            },
+            {
+              "name": "Wildhunt",
+              "description": "While shifted, you have advantage on Wisdom checks, and no creature within 30 feet of you can make an attack roll with advantage against you unless you’re incapacitated."
+            }
+          ]
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Eberron - Beasthide",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/shifter",
+      "ability_score_increase": [
+        {
+          "ability": "Constitution",
+          "increase": 2
+        },
+        {
+          "ability": "Strength",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Keen Senses",
+          "description": "You have proficiency in the Perception skill."
+        },
+        {
+          "name": "Shifting (Base ERLW)",
+          "description": "As a bonus action, you can assume a more bestial appearance. This transformation lasts for 1 minute, until you die, or until you revert to your normal appearance as a bonus action. When you shift, you gain temporary hit points equal to your level + your Constitution modifier (minimum of 1 temporary hit point). You also gain benefits that depend on your shifter subrace, described below. Once you shift, you can’t do so again until you finish a short or long rest."
+        },
+        {
+          "name": "Natural Athlete",
+          "description": "You have proficiency in the Athletics skill."
+        },
+        {
+          "name": "Shifting Feature (Beasthide)",
+          "description": "Whenever you shift, you gain 1d6 additional temporary hit points, and while shifted, you have a +1 bonus to your Armor Class."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ]
+      }
+    },
+    {
+      "version_name": "Eberron - Longtooth",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/shifter",
+      "ability_score_increase": [
+        {
+          "ability": "Strength",
+          "increase": 2
+        },
+        {
+          "ability": "Dexterity",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Keen Senses",
+          "description": "You have proficiency in the Perception skill."
+        },
+        {
+          "name": "Shifting (Base ERLW)",
+          "description": "As a bonus action, you can assume a more bestial appearance. This transformation lasts for 1 minute, until you die, or until you revert to your normal appearance as a bonus action. When you shift, you gain temporary hit points equal to your level + your Constitution modifier (minimum of 1 temporary hit point). You also gain benefits that depend on your shifter subrace, described below. Once you shift, you can’t do so again until you finish a short or long rest."
+        },
+        {
+          "name": "Fierce",
+          "description": "You have proficiency in the Intimidation skill."
+        },
+        {
+          "name": "Shifting Feature (Longtooth)",
+          "description": "While shifted, you can use your elongated fangs to make an unarmed strike as a bonus action. If you hit with your fangs, you can deal piercing damage equal to 1d6 + your Strength modifier, instead of the bludgeoning damage normal for an unarmed strike."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ]
+      }
+    },
+    {
+      "version_name": "Eberron - Swiftstride",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/shifter",
+      "ability_score_increase": [
+        {
+          "ability": "Dexterity",
+          "increase": 2
+        },
+        {
+          "ability": "Charisma",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Keen Senses",
+          "description": "You have proficiency in the Perception skill."
+        },
+        {
+          "name": "Shifting (Base ERLW)",
+          "description": "As a bonus action, you can assume a more bestial appearance. This transformation lasts for 1 minute, until you die, or until you revert to your normal appearance as a bonus action. When you shift, you gain temporary hit points equal to your level + your Constitution modifier (minimum of 1 temporary hit point). You also gain benefits that depend on your shifter subrace, described below. Once you shift, you can’t do so again until you finish a short or long rest."
+        },
+        {
+          "name": "Graceful",
+          "description": "You have proficiency in the Acrobatics skill."
+        },
+        {
+          "name": "Shifting Feature (Swiftstride)",
+          "description": "While shifted, your walking speed increases by 10 feet. Additionally, you can move up to 10 feet as a reaction when an enemy ends its turn within 5 feet of you. This reactive movement doesn’t provoke opportunity attacks."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ]
+      }
+    },
+    {
+      "version_name": "Eberron - Wildhunt",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/shifter",
+      "ability_score_increase": [
+        {
+          "ability": "Wisdom",
+          "increase": 2
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Keen Senses",
+          "description": "You have proficiency in the Perception skill."
+        },
+        {
+          "name": "Shifting (Base ERLW)",
+          "description": "As a bonus action, you can assume a more bestial appearance. This transformation lasts for 1 minute, until you die, or until you revert to your normal appearance as a bonus action. When you shift, you gain temporary hit points equal to your level + your Constitution modifier (minimum of 1 temporary hit point). You also gain benefits that depend on your shifter subrace, described below. Once you shift, you can’t do so again until you finish a short or long rest."
+        },
+        {
+          "name": "Natural Tracker",
+          "description": "You have proficiency in the Survival skill."
+        },
+        {
+          "name": "Mark the Scent",
+          "description": "As a bonus action, you can mark one creature you can see within 10 feet of you. Until the end of your next long rest, your proficiency bonus is doubled for any ability check you make to find the marked creature, and you always know the location of that creature if it is within 60 feet of you. You can’t use this trait again until you finish a short or long rest."
+        },
+        {
+          "name": "Shifting Feature (Wildhunt)",
+          "description": "While shifted, you have advantage on Wisdom checks."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/tabaxi.json
+++ b/game_data/races/tabaxi.json
@@ -1,0 +1,113 @@
+{
+  "name": "Tabaxi",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/tabaxi",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium or Small (player choice)",
+      "speed": {
+        "base": 30,
+        "climb": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Cat's Claws",
+          "description": "You can use your claws to make unarmed strikes. When you hit with them, the strike deals 1d6 + your Strength modifier slashing damage, instead of the bludgeoning damage normal for an unarmed strike."
+        },
+        {
+          "name": "Cat's Talent",
+          "description": "You have proficiency in the Perception and Stealth skills."
+        },
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Feline Agility",
+          "description": "Your reflexes and agility allow you to move with a burst of speed. When you move on your turn in combat, you can double your speed until the end of the turn. Once you use this trait, you can’t use it again until you move 0 feet on one of your turns."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Volo's Guide",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/tabaxi",
+      "ability_score_increase": [
+        {
+          "ability": "Dexterity",
+          "increase": 2
+        },
+        {
+          "ability": "Charisma",
+          "increase": 1
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30,
+        "climb": 20
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Darkvision",
+          "description": "You have a cat's keen senses, especially in the dark. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Feline Agility",
+          "description": "Your reflexes and agility allow you to move with a burst of speed. When you move on your tum in combat, you can double your speed until the end of the tum. Once you use this trait, you can't use it again until you move 0 feet on one of your turns."
+        },
+        {
+          "name": "Cat's Claws",
+          "description": "Because of your claws, you have a climbing speed of 20 feet. In addition, your claws are natural weapons, which you can use to make unarmed strikes. If you hit with them, you deal slashing damage equal to 1d4 + your Strength modifier, instead of the bludgeoning damage normal for an unarmed strike."
+        },
+        {
+          "name": "Cat's Talent",
+          "description": "You have proficiency in the Perception and Stealth skills."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language of your choice."
+      }
+    }
+  ]
+}

--- a/game_data/races/tiefling.json
+++ b/game_data/races/tiefling.json
@@ -1,0 +1,79 @@
+{
+  "name": "Tiefling",
+  "source": "Free Basic Rules (2014)",
+  "description": "Tieflings share certain racial traits as a result of their infernal descent.",
+  "ability_score_increase": {
+    "description": "Your Intelligence score increases by 1, and your Charisma score increases by 2.",
+    "abilities": [
+      {
+        "name": "Intelligence",
+        "increase": 1
+      },
+      {
+        "name": "Charisma",
+        "increase": 2
+      }
+    ]
+  },
+  "age": {
+    "description": "Tieflings mature at the same rate as humans but live a few years longer."
+  },
+  "alignment": {
+    "description": "Tieflings might not have an innate tendency toward evil, but many of them end up there. Evil or not, an independent nature inclines many tieflings toward a chaotic alignment."
+  },
+  "size": {
+    "name": "Medium",
+    "description": "Tieflings are about the same size and build as humans. Your size is Medium."
+  },
+  "speed": {
+    "base": 30,
+    "description": "Your base walking speed is 30 feet."
+  },
+  "languages": {
+    "static": [
+      "Common",
+      "Infernal"
+    ],
+    "description": "You can speak, read, and write Common and Infernal."
+  },
+  "traits": [
+    {
+      "name": "Darkvision",
+      "description": "Thanks to your infernal heritage, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+    },
+    {
+      "name": "Hellish Resistance",
+      "description": "You have resistance to fire damage."
+    },
+    {
+      "name": "Infernal Legacy",
+      "description": "You know the Thaumaturgy cantrip. Once you reach 3rd level, you can cast the Hellish Rebuke spell once as a 2nd-level spell. Once you reach 5th level, you can also cast the Darkness spell once. You must finish a long rest to cast these spells again using this trait. Charisma is your spellcasting ability for these spells.",
+      "spells": [
+        {
+          "name": "Thaumaturgy",
+          "level_requirement": 1,
+          "type": "cantrip",
+          "usage": "at will",
+          "spellcasting_ability": "Charisma"
+        },
+        {
+          "name": "Hellish Rebuke",
+          "level_requirement": 3,
+          "type": "spell",
+          "usage": "once per long rest",
+          "spell_level_cast_at": 2,
+          "spellcasting_ability": "Charisma"
+        },
+        {
+          "name": "Darkness",
+          "level_requirement": 5,
+          "type": "spell",
+          "usage": "once per long rest",
+          "spellcasting_ability": "Charisma"
+        }
+      ],
+      "options_description": "// TODO: Verify spell details and usage from a more definitive SRD source if possible."
+    }
+  ],
+  "subraces": []
+}

--- a/game_data/races/triton.json
+++ b/game_data/races/triton.json
@@ -1,0 +1,124 @@
+{
+  "name": "Triton",
+  "variants": [
+    {
+      "version_name": "Mordenkainen's Multiverse",
+      "source": "Mordenkainen Presents: Monsters of the Multiverse",
+      "source_url": "http://dnd5e.wikidot.com/triton",
+      "ability_score_increase": [
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 2
+            },
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "Increase one score by 2 and increase a different score by 1."
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 3,
+              "increase": 1
+            }
+          ],
+          "description": "Or increase three different scores by 1."
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30,
+        "swim": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "You can breathe air and water."
+        },
+        {
+          "name": "Control Air and Water",
+          "description": "You can cast Fog Cloud with this trait. Starting at 3rd level, you can cast the Gust of Wind spell with this trait. Starting at 5th level, you can also cast the Water Walk spell with it. Once you cast any of these spells with this trait, you can’t cast that spell with it again until you finish a long rest. You can also cast these spells using any spell slots you have of the appropriate level.\nIntelligence, Wisdom, or Charisma is your spellcasting ability for these spells when you cast them with this trait (choose when you select this race)."
+        },
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+        },
+        {
+          "name": "Emissary of the Sea",
+          "description": "You can communicate simple ideas to any Beast, Elemental, or Monstrosity that has a swimming speed. It can understand your words, though you have no special ability to understand it in return."
+        },
+        {
+          "name": "Guardian of the Depths",
+          "description": "Adapted to the frigid ocean depths, you have resistance to cold damage."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language that you and your DM agree is appropriate for the character."
+      }
+    },
+    {
+      "version_name": "Volo's Guide",
+      "source": "Volo's Guide to Monsters",
+      "source_url": "http://dnd5e.wikidot.com/triton",
+      "ability_score_increase": [
+        {
+          "ability": "Strength",
+          "increase": 1
+        },
+        {
+          "ability": "Constitution",
+          "increase": 1
+        },
+        {
+          "ability": "Charisma",
+          "increase": 1
+        }
+      ],
+      "size": "Medium (~5 feet tall)",
+      "speed": {
+        "base": 30,
+        "swim": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Amphibious",
+          "description": "You can breathe air and water."
+        },
+        {
+          "name": "Control Air and Water",
+          "description": "A child of the sea, you can call on the magic of elemental air and water. You can cast Fog Cloud with this trait. Starting at 3rd level, you can cast Gust of Wind with it, and starting at 5th level, you can also cast Wall of Water with it. Once you cast a spell with this trait, you can’t cast that spell with it again until you finish a long rest. Charisma is your spellcasting ability for these spells."
+        },
+        {
+          "name": "Darkvision",
+          "description": "You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
+        },
+        {
+          "name": "Emissary of the Sea",
+          "description": "Aquatic beasts have an extraordinary affinity with your people. You can communicate simple ideas with beasts that can breathe water. They can understand the meaning of your words, though you have no special ability to understand them in return."
+        },
+        {
+          "name": "Guardians of the Depths",
+          "description": "Adapted to even the most extreme ocean depths, you have resistance to cold damage."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common",
+          "Primordial"
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/races/warforged_erlw.json
+++ b/game_data/races/warforged_erlw.json
@@ -1,0 +1,56 @@
+{
+  "name": "Warforged",
+  "variants": [
+    {
+      "version_name": "Eberron - Rising from the Last War",
+      "source": "Eberron - Rising from the Last War",
+      "source_url": "http://dnd5e.wikidot.com/warforged",
+      "ability_score_increase": [
+        {
+          "ability": "Constitution",
+          "increase": 2
+        },
+        {
+          "type": "flexible",
+          "options": [
+            {
+              "choose": 1,
+              "increase": 1
+            }
+          ],
+          "description": "one other ability score of your choice increases by 1."
+        }
+      ],
+      "size": "Medium",
+      "speed": {
+        "base": 30
+      },
+      "creature_type": "Humanoid",
+      "traits": [
+        {
+          "name": "Constructed Resilience",
+          "description": "You were created to have remarkable fortitude, represented by the following benefits:\n- You have advantage on saving throws against being poisoned, and you have resistance to poison damage.\n- You don’t need to eat, drink, or breathe.\n- You are immune to disease.\n- You don't need to sleep, and magic can't put you to sleep."
+        },
+        {
+          "name": "Sentry's Rest",
+          "description": "When you take a long rest, you must spend at least six hours in an inactive, motionless state, rather than sleeping. In this state, you appear inert, but it doesn’t render you unconscious, and you can see and hear as normal."
+        },
+        {
+          "name": "Integrated Protection",
+          "description": "Your body has built-in defensive layers, which can be enhanced with armor.\n- You gain a +1 bonus to Armor Class.\n- You can don only armor with which you have proficiency. To don armor, you must incorporate it into your body over the course of 1 hour, during which you must remain in contact with the armor. To doff armor, you must spend 1 hour removing it. You can rest while donning or doffing armor in this way.\n- While you live, your armor can't be removed from your body against your will."
+        },
+        {
+          "name": "Specialized Design",
+          "description": "You gain one skill proficiency and one tool proficiency of your choice."
+        }
+      ],
+      "languages": {
+        "known": [
+          "Common"
+        ],
+        "choose": 1,
+        "options_description": "one other language of your choice."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
…ces and their significant variants, transcribed from dnd5e.wikidot.com. This data complements the previously added SRD races.

Key changes:
- Added new JSON files for the following broad race concepts to `game_data/races/`:
    - aasimar.json
    - firbolg.json
    - goliath.json
    - kenku.json
    - lizardfolk.json
    - tabaxi.json
    - triton.json
    - warforged_erlw.json (Eberron: Rising from the Last War version)
    - shifter.json
    - changeling.json
    - kalashtar_erlw.json (Eberron: Rising from the Last War version)
    - orc.json
    - genasi_air.json
    - genasi_earth.json
    - genasi_fire.json
    - genasi_water.json
- Each file uses a new structure: a top-level "name" for the race concept, and a "variants" array. Each element in "variants" is an object representing a distinct published version (e.g., from MPMM, ERLW, VGtM, EEPC), detailing its specific source, traits, ASIs, etc.
- This structure allows multiple official versions of a race (e.g., MPMM Orc, Eberron Orc) to be stored and accessed.
- For races like Shifter, the MPMM version includes its shifting feature choices, while the ERLW variants (Beasthide, Longtooth etc.) are included as distinct entries within shifter.json, reflecting their unique ASIs and ERLW-specific mechanics.
- Updated `game_data/races/README.md` to explain the inclusion of expansion race data, the new 'variants' structure, and the sources used (primarily dnd5e.wikidot.com, referencing specific books like MPMM, ERLW, etc.).

The data aims to capture the latest official rules (like MPMM) as the primary variant where available, while also providing older or setting-specific versions for broader utility.