### PR TITLE
I've added the Artificer class and its initial subclasses (Alchemist,…

### DIFF
--- a/game_data/classes/artificer.json
+++ b/game_data/classes/artificer.json
@@ -1,0 +1,136 @@
+{
+  "name": "Artificer",
+  "source": "Tasha's Cauldron of Everything / Eberron: Rising from the Last War",
+  "description": "Masters of invention, artificers use ingenuity and magic to unlock extraordinary capabilities in objects. They see magic as a complex system waiting to be decoded and then harnessed in their spells and inventions.",
+  "hit_points": {
+    "hit_dice": "1d8 per artificer level",
+    "hp_at_1st_level": "8 + your Constitution modifier",
+    "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per artificer level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["Light armor", "medium armor", "shields"],
+    "weapons": ["Simple weapons"],
+    "tools": ["Thieves’ tools", "tinker’s tools", "one type of artisan’s tools of your choice"],
+    "saving_throws": ["Constitution", "Intelligence"],
+    "skills": {
+      "choose_from": ["Arcana", "History", "Investigation", "Medicine", "Nature", "Perception", "Sleight of Hand"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "any two simple weapons",
+    "a light crossbow and 20 bolts",
+    "(a) studded leather armor or (b) scale mail",
+    "thieves’ tools and a dungeoneer’s pack"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Magical Tinkering, Spellcasting", "infusions_known": 0, "infused_items": 0, "cantrips_known": 2, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "2": {"proficiency_bonus": 2, "features": "Infuse Item", "infusions_known": 4, "infused_items": 2, "cantrips_known": 2, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "3": {"proficiency_bonus": 2, "features": "Artificer Specialist, The Right Tool for the Job", "infusions_known": 4, "infused_items": 2, "cantrips_known": 2, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "infusions_known": 4, "infused_items": 2, "cantrips_known": 2, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "5": {"proficiency_bonus": 3, "features": "Artificer Specialist feature", "infusions_known": 4, "infused_items": 2, "cantrips_known": 2, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "6": {"proficiency_bonus": 3, "features": "Tool Expertise", "infusions_known": 6, "infused_items": 3, "cantrips_known": 2, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "7": {"proficiency_bonus": 3, "features": "Flash of Genius", "infusions_known": 6, "infused_items": 3, "cantrips_known": 2, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement", "infusions_known": 6, "infused_items": 3, "cantrips_known": 2, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "9": {"proficiency_bonus": 4, "features": "Artificer Specialist feature", "infusions_known": 6, "infused_items": 3, "cantrips_known": 2, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "10": {"proficiency_bonus": 4, "features": "Magic Item Adept", "infusions_known": 8, "infused_items": 4, "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "11": {"proficiency_bonus": 4, "features": "Spell-Storing Item", "infusions_known": 8, "infused_items": 4, "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "infusions_known": 8, "infused_items": 4, "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "13": {"proficiency_bonus": 5, "features": "-", "infusions_known": 8, "infused_items": 4, "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0},
+    "14": {"proficiency_bonus": 5, "features": "Magic Item Savant", "infusions_known": 10, "infused_items": 5, "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0},
+    "15": {"proficiency_bonus": 5, "features": "Artificer Specialist feature", "infusions_known": 10, "infused_items": 5, "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "infusions_known": 10, "infused_items": 5, "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0},
+    "17": {"proficiency_bonus": 6, "features": "-", "infusions_known": 10, "infused_items": 5, "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1},
+    "18": {"proficiency_bonus": 6, "features": "Magic Item Master", "infusions_known": 12, "infused_items": 6, "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "infusions_known": 12, "infused_items": 6, "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2},
+    "20": {"proficiency_bonus": 6, "features": "Soul of Artifice", "infusions_known": 12, "infused_items": 6, "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2}
+  },
+  "subclasses_title": "Artificer Specialist",
+  "subclasses": [
+    {
+      "name": "Alchemist",
+      "source": "Tasha's Cauldron of Everything / Eberron: Rising from the Last War",
+      "description": "An Alchemist is an expert at combining reagents to produce mystical effects. Alchemists use their creations to give life and to leech it away. Alchemy is the oldest of artificer traditions, and its versatility has long been valued during times of war and peace.",
+      "specialist_spells": {
+        "3": ["Healing Word", "Ray of Sickness"],
+        "5": ["Flaming Sphere", "Melf's Acid Arrow"],
+        "9": ["Gaseous Form", "Mass Healing Word"],
+        "13": ["Blight", "Death Ward"],
+        "17": ["Cloudkill", "Raise Dead"]
+      },
+      "features_by_level": {
+        "3": [
+          {"name": "Tool Proficiency", "description": "You gain proficiency with alchemist's supplies. If you already have this proficiency, you gain proficiency with one other type of artisan's tools of your choice."},
+          {"name": "Alchemist Spells", "description": "You always have certain spells prepared after you reach particular levels in this class, as shown in the Alchemist Spells table. These spells count as artificer spells for you, but they don’t count against the number of artificer spells you prepare."},
+          {"name": "Experimental Elixir", "description": "Whenever you finish a long rest, you can magically produce an experimental elixir in an empty flask you touch. Roll on the Experimental Elixir table for the elixir's effect, which is triggered when someone drinks the elixir. As an action, a creature can drink the elixir or administer it to an incapacitated creature. You can create additional experimental elixirs by expending a spell slot of 1st level or higher for each one. When you do so, you use your action to create the elixir in an empty flask you touch, and you choose the elixir's effect from the Experimental Elixir table. Creating an experimental elixir requires you to have alchemist supplies on your person, and any elixir you create with this feature lasts until it is drunk or until the end of your next long rest. When you reach certain levels in this class, you can make more elixirs at the end of a long rest: two at 6th level and three at 15th level. Roll for each elixir's effect separately. Each elixir requires its own flask."}
+        ],
+        "5": [
+          {"name": "Alchemical Savant", "description": "You've developed masterful command of magical chemicals, enhancing the healing and damage you create through them. Whenever you cast a spell using your alchemist's supplies as the spellcasting focus, you gain a bonus to one roll of the spell. That roll must restore hit points or be a damage roll that deals acid, fire, necrotic, or poison damage, and the bonus equals your Intelligence modifier (minimum of +1)."}
+        ],
+        "9": [
+          {"name": "Restorative Reagents", "description": "You can incorporate restorative reagents into some of your works: Whenever a creature drinks an experimental elixir you created, the creature gains temporary hit points equal to 2d6 + your Intelligence modifier (minimum of 1 temporary hit point). You can cast Lesser Restoration without expending a spell slot and without preparing the spell, provided you use alchemist's supplies as the spellcasting focus. You can do so a number of times equal to your Intelligence modifier (minimum of once), and you regain all expended uses when you finish a long rest."}
+        ],
+        "15": [
+          {"name": "Chemical Mastery", "description": "You have been exposed to so many chemicals that they pose little risk to you, and you can use them to quickly end certain ailments: You gain resistance to acid damage and poison damage, and you are now immune to the poisoned condition. You can cast Greater Restoration and Heal without expending a spell slot, without preparing the spell, and without providing the material component, provided you use alchemist’s supplies as the spellcasting focus. Once you cast either spell with this feature, you can't cast that spell with it again until you finish a long rest."}
+        ]
+      }
+    },
+    {
+      "name": "Armorer",
+      "source": "Tasha's Cauldron of Everything",
+      "description": "An artificer who specializes as an Armorer modifies armor to function almost like a second skin. The armor is enhanced to hone the artificer's magic, unleash potent attacks, and generate a formidable defense.",
+      "specialist_spells": {
+        "3": ["Magic Missile", "Thunderwave"],
+        "5": ["Mirror Image", "Shatter"],
+        "9": ["Hypnotic Pattern", "Lightning Bolt"],
+        "13": ["Fire Shield", "Greater Invisibility"],
+        "17": ["Passwall", "Wall of Force"]
+      },
+      "features_by_level": {
+        "3": [
+          {"name": "Tools of the Trade", "description": "You gain proficiency with heavy armor. You also gain proficiency with smith's tools. If you already have this tool proficiency, you gain proficiency with one other type of artisan's tools of your choice."},
+          {"name": "Armorer Spells", "description": "You always have certain spells prepared after you reach particular levels in this class, as shown in the Armorer Spells table. These spells count as artificer spells for you, but they don’t count against the number of artificer spells you prepare."},
+          {"name": "Arcane Armor", "description": "Your metallurgical pursuits have led to you making armor a conduit for your magic. As an action, you can turn a suit of armor you are wearing into Arcane Armor, provided you have smith's tools in hand. You gain benefits while wearing this armor: lacks Strength requirement, can be spellcasting focus, attaches to you and can’t be removed against your will, replaces missing limbs, can be donned/doffed as an action. Continues until you don another suit or die."},
+          {"name": "Armor Model", "description": "Choose Guardian or Infiltrator model. Each includes a special weapon (use Int for attack/damage). Can change model on short/long rest. Guardian: Thunder Gauntlets (1d8 thunder, target has disadvantage on attacks vs others), Defensive Field (bonus action for temp HP = level, PB uses/long rest). Infiltrator: Lightning Launcher (1d6 lightning, 90/300ft range, extra 1d6 once/turn), Powered Steps (+5ft speed), Dampening Field (Adv. on Stealth)."}
+        ],
+        "5": [
+          {"name": "Extra Attack", "description": "You can attack twice, rather than once, whenever you take the Attack action on your turn."}
+        ],
+        "9": [
+          {"name": "Armor Modifications", "description": "Your Arcane Armor now counts as separate items for Infuse Items: armor (chest piece), boots, helmet, and special weapon. Each can bear one infusion. Max infused items increases by 2 (must be part of Arcane Armor)."}
+        ],
+        "15": [
+          {"name": "Perfected Armor", "description": "Guardian: Reaction to force Huge or smaller creature within 30ft to make Str save or be pulled 25ft; if pulled to within 5ft, can make melee attack. PB uses/long rest. Infiltrator: Creature taking lightning damage from Lightning Launcher glimmers (dim light 5ft radius), has disadvantage on attacks vs you, next attack vs it has advantage and deals extra 1d6 lightning."}
+        ]
+      }
+    },
+    {
+      "name": "Artillerist",
+      "source": "Tasha's Cauldron of Everything / Eberron: Rising from the Last War",
+      "description": "An Artillerist specializes in using magic to hurl energy, projectiles, and explosions on a battlefield. This destructive power is valued by armies in the wars on many different worlds.",
+      "specialist_spells": {
+        "3": ["Shield", "Thunderwave"],
+        "5": ["Scorching Ray", "Shatter"],
+        "9": ["Fireball", "Wind Wall"],
+        "13": ["Ice Storm", "Wall of Fire"],
+        "17": ["Cone of Cold", "Wall of Force"]
+      },
+      "features_by_level": {
+        "3": [
+          {"name": "Tool Proficiency", "description": "You gain proficiency with woodcarver's tools. If you already have this proficiency, you gain proficiency with one other type of artisan's tools of your choice."},
+          {"name": "Artillerist Spells", "description": "You always have certain spells prepared after you reach particular levels in this class, as shown in the Artillerist Spells table. These spells count as artificer spells for you, but they don’t count against the number of artificer spells you prepare."},
+          {"name": "Eldritch Cannon", "description": "You've learned how to create a magical cannon. Using woodcarver's tools or smith's tools, you can take an action to magically create a Small or Tiny eldritch cannon. You decide its appearance and if it has legs. Choose its type: Flamethrower (15-foot cone, 2d8 fire damage, Dex save for half), Force Ballista (ranged spell attack, 120ft, 2d8 force damage, push 5ft), or Protector (grants self and creatures within 10ft 1d8 + Int mod temp HP). You can activate the cannon as a bonus action (can also move it 15ft if it has legs). AC 18, HP = 5 x artificer level. Immune to poison/psychic. Regains 2d6 HP from mending. Disappears if 0 HP or after 1 hour. Can create one per long rest or by expending a spell slot."}
+        ],
+        "5": [
+          {"name": "Arcane Firearm", "description": "You know how to turn a wand, staff, or rod into an arcane firearm. When you finish a long rest, you can use woodcarver's tools to carve special sigils into it. You can use your arcane firearm as a spellcasting focus. When you cast an artificer spell through the firearm, roll a d8, and you gain a bonus to one of the spell's damage rolls equal to the number rolled."}
+        ],
+        "9": [
+          {"name": "Explosive Cannon", "description": "The cannon's damage rolls all increase by 1d8. As an action, you can command the cannon to detonate if you are within 60 feet of it. Doing so destroys the cannon and forces each creature within 20 feet of it to make a Dexterity saving throw against your spell save DC, taking 3d8 force damage on a failed save or half as much damage on a successful one."}
+        ],
+        "15": [
+          {"name": "Fortified Position", "description": "You and your allies have half cover while within 10 feet of a cannon you create with Eldritch Cannon. You can now have two cannons at the same time. You can create two with the same action (but not the same spell slot), and you can activate both of them with the same bonus action. You determine whether the cannons are identical to each other or different. You can't create a third cannon while you have two."}
+        ]
+      }
+    }
+  ]
+}

--- a/game_data/classes/barbarian.json
+++ b/game_data/classes/barbarian.json
@@ -1,0 +1,61 @@
+{
+  "name": "Barbarian",
+  "source": "Player's Handbook",
+  "description": "A fierce warrior of primitive background who can enter a battle rage.",
+  "hit_points": {
+    "hit_dice": "1d12 per barbarian level",
+    "hp_at_1st_level": "12 + your Constitution modifier",
+    "hp_at_higher_levels": "1d12 (or 7) + your Constitution modifier per barbarian level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["Light armor", "medium armor", "shields"],
+    "weapons": ["Simple weapons", "martial weapons"],
+    "tools": ["None"],
+    "saving_throws": ["Strength", "Constitution"],
+    "skills": {
+      "choose_from": ["Animal Handling", "Athletics", "Intimidation", "Nature", "Perception", "Survival"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a greataxe or (b) any martial melee weapon",
+    "(a) two handaxes or (b) any simple weapon",
+    "An explorer’s pack and four javelins"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Rage, Unarmored Defense", "rages": "2", "rage_damage": "+2"},
+    "2": {"proficiency_bonus": 2, "features": "Reckless Attack, Danger Sense", "rages": "2", "rage_damage": "+2"},
+    "3": {"proficiency_bonus": 2, "features": "Primal Path", "rages": "3", "rage_damage": "+2"},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "rages": "3", "rage_damage": "+2"},
+    "5": {"proficiency_bonus": 3, "features": "Extra Attack, Fast Movement", "rages": "3", "rage_damage": "+2"},
+    "6": {"proficiency_bonus": 3, "features": "Path feature", "rages": "4", "rage_damage": "+2"},
+    "7": {"proficiency_bonus": 3, "features": "Feral Instinct", "rages": "4", "rage_damage": "+2"},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement", "rages": "4", "rage_damage": "+2"},
+    "9": {"proficiency_bonus": 4, "features": "Brutal Critical (1 die)", "rages": "4", "rage_damage": "+3"},
+    "10": {"proficiency_bonus": 4, "features": "Path feature", "rages": "4", "rage_damage": "+3"},
+    "11": {"proficiency_bonus": 4, "features": "Relentless Rage", "rages": "4", "rage_damage": "+3"},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "rages": "5", "rage_damage": "+3"},
+    "13": {"proficiency_bonus": 5, "features": "Brutal Critical (2 dice)", "rages": "5", "rage_damage": "+3"},
+    "14": {"proficiency_bonus": 5, "features": "Path feature", "rages": "5", "rage_damage": "+3"},
+    "15": {"proficiency_bonus": 5, "features": "Persistent Rage", "rages": "5", "rage_damage": "+3"},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "rages": "5", "rage_damage": "+4"},
+    "17": {"proficiency_bonus": 6, "features": "Brutal Critical (3 dice)", "rages": "6", "rage_damage": "+4"},
+    "18": {"proficiency_bonus": 6, "features": "Indomitable Might", "rages": "6", "rage_damage": "+4"},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "rages": "6", "rage_damage": "+4"},
+    "20": {"proficiency_bonus": 6, "features": "Primal Champion", "rages": "Unlimited", "rage_damage": "+4"}
+  },
+  "subclasses_title": "Primal Path",
+  "subclasses": [
+    {
+      "name": "Path of the Berserker",
+      "source": "Player's Handbook",
+      "description": "For some barbarians, rage is a means to an end— that end being violence. The Path of the Berserker is a path of untrammeled fury, slick with blood. As you enter the berserker’s rage, you thrill in the chaos of battle, heedless of your own health or well-being.",
+      "features_by_level": {
+        "3": ["Frenzy"],
+        "6": ["Mindless Rage"],
+        "10": ["Intimidating Presence"],
+        "14": ["Retaliation"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/bard.json
+++ b/game_data/classes/bard.json
@@ -1,0 +1,61 @@
+{
+  "name": "Bard",
+  "source": "Player's Handbook",
+  "description": "An inspiring musician or orator whose magic comes from the heart and soul they pour into their performance.",
+  "hit_points": {
+    "hit_dice": "1d8 per bard level",
+    "hp_at_1st_level": "8 + your Constitution modifier",
+    "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per bard level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["Light armor"],
+    "weapons": ["Simple weapons", "hand crossbows", "longswords", "rapiers", "shortswords"],
+    "tools": ["Three musical instruments of your choice"],
+    "saving_throws": ["Dexterity", "Charisma"],
+    "skills": {
+      "choose_from": ["Acrobatics", "Animal Handling", "Arcana", "Athletics", "Deception", "History", "Insight", "Intimidation", "Investigation", "Medicine", "Nature", "Perception", "Performance", "Persuasion", "Religion", "Sleight of Hand", "Stealth", "Survival"],
+      "count": 3
+    }
+  },
+  "equipment": [
+    "(a) a rapier, (b) a longsword, or (c) any simple weapon",
+    "(a) a diplomat's pack or (b) an entertainer's pack",
+    "(a) a lute or (b) any other musical instrument",
+    "Leather Armor, and a dagger"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Spellcasting, Bardic Inspiration (d6)", "cantrips_known": 2, "spells_known": 4, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "2": {"proficiency_bonus": 2, "features": "Jack of All Trades, Song of Rest (d6)", "cantrips_known": 2, "spells_known": 5, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "3": {"proficiency_bonus": 2, "features": "Bard College, Expertise", "cantrips_known": 2, "spells_known": 6, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "cantrips_known": 3, "spells_known": 7, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "5": {"proficiency_bonus": 3, "features": "Bardic Inspiration (d8), Font of Inspiration", "cantrips_known": 3, "spells_known": 8, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "6": {"proficiency_bonus": 3, "features": "Countercharm, Bard College feature", "cantrips_known": 3, "spells_known": 9, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "7": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 3, "spells_known": 10, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement", "cantrips_known": 3, "spells_known": 11, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "9": {"proficiency_bonus": 4, "features": "Song of Rest (d8)", "cantrips_known": 3, "spells_known": 12, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "10": {"proficiency_bonus": 4, "features": "Bardic Inspiration (d10), Expertise, Magical Secrets", "cantrips_known": 4, "spells_known": 14, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "11": {"proficiency_bonus": 4, "features": "-", "cantrips_known": 4, "spells_known": 15, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "cantrips_known": 4, "spells_known": 15, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "13": {"proficiency_bonus": 5, "features": "Song of Rest (d10)", "cantrips_known": 4, "spells_known": 16, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "14": {"proficiency_bonus": 5, "features": "Magical Secrets, Bard College feature", "cantrips_known": 4, "spells_known": 18, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "15": {"proficiency_bonus": 5, "features": "Bardic Inspiration (d12)", "cantrips_known": 4, "spells_known": 19, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "cantrips_known": 4, "spells_known": 19, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "17": {"proficiency_bonus": 6, "features": "Song of Rest (d12)", "cantrips_known": 4, "spells_known": 20, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "18": {"proficiency_bonus": 6, "features": "Magical Secrets", "cantrips_known": 4, "spells_known": 22, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "cantrips_known": 4, "spells_known": 22, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "20": {"proficiency_bonus": 6, "features": "Superior Inspiration", "cantrips_known": 4, "spells_known": 22, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 2, "spell_slots_8th": 1, "spell_slots_9th": 1}
+  },
+  "subclasses_title": "Bard College",
+  "subclasses": [
+    {
+      "name": "College of Lore",
+      "source": "Player's Handbook",
+      "description": "Bards of the College of Lore know something about most things, collecting bits of knowledge from sources as diverse as scholarly tomes and peasant tales. Whether singing folk ballads in taverns or elaborate compositions in royal courts, these bards use their gifts to hold audiences spellbound.",
+      "features_by_level": {
+        "3": ["Bonus Proficiencies", "Cutting Words"],
+        "6": ["Additional Magical Secrets"],
+        "14": ["Peerless Skill"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/cleric.json
+++ b/game_data/classes/cleric.json
@@ -1,0 +1,72 @@
+{
+  "name": "Cleric",
+  "source": "Player's Handbook",
+  "description": "A priestly champion who wields divine magic in service of a higher power.",
+  "hit_points": {
+    "hit_dice": "1d8 per cleric level",
+    "hp_at_1st_level": "8 + your Constitution modifier",
+    "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per cleric level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["Light armor", "medium armor", "shields"],
+    "weapons": ["Simple weapons"],
+    "tools": ["None"],
+    "saving_throws": ["Wisdom", "Charisma"],
+    "skills": {
+      "choose_from": ["History", "Insight", "Medicine", "Persuasion", "Religion"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a mace or (b) a warhammer (if proficient)",
+    "(a) Scale Mail, (b) Leather Armor, or (c) Chain Mail (if proficient)",
+    "(a) a light crossbow and 20 bolts or (b) any simple weapon",
+    "(a) a priest's pack or (b) an explorer's pack",
+    "A shield and a holy symbol"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Spellcasting, Divine Domain", "cantrips_known": 3, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "2": {"proficiency_bonus": 2, "features": "Channel Divinity (1/rest), Divine Domain feature", "cantrips_known": 3, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "3": {"proficiency_bonus": 2, "features": "-", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "5": {"proficiency_bonus": 3, "features": "Destroy Undead (CR 1/2)", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "6": {"proficiency_bonus": 3, "features": "Channel Divinity (2/rest), Divine Domain feature", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "7": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement, Destroy Undead (CR 1), Divine Domain feature", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "9": {"proficiency_bonus": 4, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "10": {"proficiency_bonus": 4, "features": "Divine Intervention", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "11": {"proficiency_bonus": 4, "features": "Destroy Undead (CR 2)", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "13": {"proficiency_bonus": 5, "features": "-", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "14": {"proficiency_bonus": 5, "features": "Destroy Undead (CR 3)", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "15": {"proficiency_bonus": 5, "features": "-", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "17": {"proficiency_bonus": 6, "features": "Destroy Undead (CR 4), Divine Domain feature", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "18": {"proficiency_bonus": 6, "features": "Channel Divinity (3/rest)", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "20": {"proficiency_bonus": 6, "features": "Divine Intervention improvement", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 2, "spell_slots_8th": 1, "spell_slots_9th": 1}
+  },
+  "subclasses_title": "Divine Domain",
+  "subclasses": [
+    {
+      "name": "Life Domain",
+      "source": "Player's Handbook",
+      "description": "The Life domain focuses on the vibrant positive energy—one of the fundamental forces of the universe—that sustains all life. The gods of life promote vitality and health through healing the sick and wounded, caring for those in need, and driving away the forces of death and undeath.",
+      "domain_spells": {
+        "1": ["Bless", "Cure Wounds"],
+        "3": ["Lesser Restoration", "Spiritual Weapon"],
+        "5": ["Beacon of Hope", "Revivify"],
+        "7": ["Death Ward", "Guardian of Faith"],
+        "9": ["Mass Cure Wounds", "Raise Dead"]
+      },
+      "features_by_level": {
+        "1": ["Bonus Proficiency (Heavy Armor)", "Disciple of Life"],
+        "2": ["Channel Divinity: Preserve Life"],
+        "6": ["Blessed Healer"],
+        "8": ["Divine Strike (1d8 radiant damage)"],
+        "14": ["Divine Strike improvement (2d8 radiant damage)"],
+        "17": ["Supreme Healing"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/druid.json
+++ b/game_data/classes/druid.json
@@ -1,0 +1,112 @@
+{
+  "name": "Druid",
+  "source": "Player's Handbook",
+  "description": "A priest of the Old Faith, wielding the powers of nature—moonlight and plant growth, fire and lightning—and adopting animal forms.",
+  "hit_points": {
+    "hit_dice": "1d8 per druid level",
+    "hp_at_1st_level": "8 + your Constitution modifier",
+    "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per druid level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["light armor", "medium armor", "shields (druids will not wear armor or use shields made of metal)"],
+    "weapons": ["clubs", "daggers", "darts", "javelins", "maces", "quarterstaffs", "scimitars", "sickles", "slings", "spears"],
+    "tools": ["herbalism kit"],
+    "saving_throws": ["Intelligence", "Wisdom"],
+    "skills": {
+      "choose_from": ["Arcana", "Animal Handling", "Insight", "Medicine", "Nature", "Perception", "Religion", "Survival"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a wooden shield or (b) any simple weapon",
+    "(a) a scimitar or (b) any simple melee weapon",
+    "Leather Armor, an explorer's pack, and a druidic focus"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Druidic, Spellcasting", "cantrips_known": 2, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "2": {"proficiency_bonus": 2, "features": "Wild Shape, Druid Circle", "cantrips_known": 2, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "3": {"proficiency_bonus": 2, "features": "-", "cantrips_known": 2, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "4": {"proficiency_bonus": 2, "features": "Wild Shape improvement, Ability Score Improvement", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "5": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "6": {"proficiency_bonus": 3, "features": "Druid Circle feature", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "7": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "8": {"proficiency_bonus": 3, "features": "Wild Shape improvement, Ability Score Improvement", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "9": {"proficiency_bonus": 4, "features": "-", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "10": {"proficiency_bonus": 4, "features": "Druid Circle feature", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "11": {"proficiency_bonus": 4, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "13": {"proficiency_bonus": 5, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "14": {"proficiency_bonus": 5, "features": "Druid Circle feature", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "15": {"proficiency_bonus": 5, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "17": {"proficiency_bonus": 6, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "18": {"proficiency_bonus": 6, "features": "Timeless Body, Beast Spells", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "20": {"proficiency_bonus": 6, "features": "Archdruid", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 2, "spell_slots_8th": 1, "spell_slots_9th": 1}
+  },
+  "subclasses_title": "Druid Circle",
+  "subclasses": [
+    {
+      "name": "Circle of the Land",
+      "source": "Player's Handbook",
+      "description": "The Circle of the Land is made up of mystics and sages who safeguard ancient knowledge and rites through a vast oral tradition. These druids meet within sacred circles of trees or standing stones to whisper primal secrets in Druidic.",
+      "features_by_level": {
+        "2": ["Bonus Cantrip", "Natural Recovery"],
+        "3": ["Circle Spells"],
+        "5": ["Circle Spells"],
+        "6": ["Land’s Stride"],
+        "7": ["Circle Spells"],
+        "9": ["Circle Spells"],
+        "10": ["Nature’s Ward"],
+        "14": ["Nature’s Sanctuary"]
+      },
+      "circle_spells_options": {
+        "description": "Your mystical connection to the land infuses you with the ability to cast certain spells. At 3rd, 5th, 7th, and 9th level you gain access to circle spells connected to the land where you became a druid. Choose that land—arctic, coast, desert, forest, grassland, mountain, or swamp—and consult the associated list of spells. Once you gain access to a circle spell, you always have it prepared, and it doesn’t count against the number of spells you can prepare each day. If you gain access to a spell that doesn’t appear on the druid spell list, the spell is nonetheless a druid spell for you.",
+        "lands": {
+          "Arctic": {
+            "3": ["Hold Person", "Spike Growth"],
+            "5": ["Sleet Storm", "Slow"],
+            "7": ["Freedom of Movement", "Ice Storm"],
+            "9": ["Commune with Nature", "Cone of Cold"]
+          },
+          "Coast": {
+            "3": ["Mirror Image", "Misty Step"],
+            "5": ["Water Breathing", "Water Walk"],
+            "7": ["Control Water", "Freedom of Movement"],
+            "9": ["Conjure Elemental", "Scrying"]
+          },
+          "Desert": {
+            "3": ["Blur", "Silence"],
+            "5": ["Create Food and Water", "Protection from Energy"],
+            "7": ["Blight", "Hallucinatory Terrain"],
+            "9": ["Insect Plague", "Wall of Stone"]
+          },
+          "Forest": {
+            "3": ["Barkskin", "Spider Climb"],
+            "5": ["Call Lightning", "Plant Growth"],
+            "7": ["Divination", "Freedom of Movement"],
+            "9": ["Commune with Nature", "Tree Stride"]
+          },
+          "Grassland": {
+            "3": ["Invisibility", "Pass Without Trace"],
+            "5": ["Daylight", "Haste"],
+            "7": ["Divination", "Freedom of Movement"],
+            "9": ["Dream", "Insect Plague"]
+          },
+          "Mountain": {
+            "3": ["Spider Climb", "Spike Growth"],
+            "5": ["Lightning Bolt", "Meld into Stone"],
+            "7": ["Stone Shape", "Stoneskin"],
+            "9": ["Passwall", "Wall of Stone"]
+          },
+          "Swamp": {
+            "3": ["Acid Arrow", "Darkness"],
+            "5": ["Water Walk", "Stinking Cloud"],
+            "7": ["Freedom of Movement", "Locate Creature"],
+            "9": ["Insect Plague", "Scrying"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/game_data/classes/fighter.json
+++ b/game_data/classes/fighter.json
@@ -1,0 +1,92 @@
+{
+  "name": "Fighter",
+  "source": "Player's Handbook",
+  "description": "A master of martial combat, skilled with a variety of weapons and armor.",
+  "hit_points": {
+    "hit_dice": "1d10 per fighter level",
+    "hp_at_1st_level": "10 + your Constitution modifier",
+    "hp_at_higher_levels": "1d10 (or 6) + your Constitution modifier per fighter level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["light armor", "medium armor", "heavy armor", "shields"],
+    "weapons": ["simple weapons", "martial weapons"],
+    "tools": ["None"],
+    "saving_throws": ["Strength", "Constitution"],
+    "skills": {
+      "choose_from": ["Acrobatics", "Animal Handling", "Athletics", "History", "Insight", "Intimidation", "Perception", "Survival"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) Chain Mail or (b) leather armor, longbow, and 20 arrows",
+    "(a) a martial weapon and a shield or (b) two martial weapons",
+    "(a) a light crossbow and 20 bolts or (b) two handaxes",
+    "(a) a dungeoneer's pack or (b) an explorer's pack"
+  ],
+  "fighting_styles": {
+    "description": "You adopt a particular style of fighting as your specialty. Choose one at 1st level. You can't take the same Fighting Style option more than once, even if you get to choose again.",
+    "options": [
+      {
+        "name": "Archery",
+        "description": "You gain a +2 bonus to attack rolls you make with ranged weapons."
+      },
+      {
+        "name": "Defense",
+        "description": "While you are wearing armor, you gain a +1 bonus to AC."
+      },
+      {
+        "name": "Dueling",
+        "description": "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon."
+      },
+      {
+        "name": "Great Weapon Fighting",
+        "description": "When you roll a 1 or 2 on a damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the die and must use the new roll, even if the new roll is a 1 or a 2. The weapon must have the two-handed or versatile property for you to gain this benefit."
+      },
+      {
+        "name": "Protection",
+        "description": "When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a shield."
+      },
+      {
+        "name": "Two-Weapon Fighting",
+        "description": "When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack."
+      }
+    ]
+  },
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Fighting Style, Second Wind"},
+    "2": {"proficiency_bonus": 2, "features": "Action Surge (one use)"},
+    "3": {"proficiency_bonus": 2, "features": "Martial Archetype"},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement"},
+    "5": {"proficiency_bonus": 3, "features": "Extra Attack"},
+    "6": {"proficiency_bonus": 3, "features": "Ability Score Improvement"},
+    "7": {"proficiency_bonus": 3, "features": "Martial Archetype feature"},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement"},
+    "9": {"proficiency_bonus": 4, "features": "Indomitable (one use)"},
+    "10": {"proficiency_bonus": 4, "features": "Martial Archetype feature"},
+    "11": {"proficiency_bonus": 4, "features": "Extra Attack (2)"},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement"},
+    "13": {"proficiency_bonus": 5, "features": "Indomitable (two uses)"},
+    "14": {"proficiency_bonus": 5, "features": "Ability Score Improvement"},
+    "15": {"proficiency_bonus": 5, "features": "Martial Archetype feature"},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement"},
+    "17": {"proficiency_bonus": 6, "features": "Action Surge (two uses), Indomitable (three uses)"},
+    "18": {"proficiency_bonus": 6, "features": "Martial Archetype feature"},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement"},
+    "20": {"proficiency_bonus": 6, "features": "Extra Attack (3)"}
+  },
+  "subclasses_title": "Martial Archetype",
+  "subclasses": [
+    {
+      "name": "Champion",
+      "source": "Player's Handbook",
+      "description": "The archetypal Champion focuses on the development of raw physical power honed to deadly perfection. Those who model themselves on this archetype combine rigorous training with physical excellence to deal devastating blows.",
+      "features_by_level": {
+        "3": ["Improved Critical"],
+        "7": ["Remarkable Athlete"],
+        "10": ["Additional Fighting Style"],
+        "15": ["Superior Critical"],
+        "18": ["Survivor"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/monk.json
+++ b/game_data/classes/monk.json
@@ -1,0 +1,61 @@
+{
+  "name": "Monk",
+  "source": "Player's Handbook",
+  "description": "A master of martial arts, harnessing the power of the body in pursuit of physical and spiritual perfection.",
+  "hit_points": {
+    "hit_dice": "1d8 per monk level",
+    "hp_at_1st_level": "8 + your Constitution modifier",
+    "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per monk level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["None"],
+    "weapons": ["simple weapons", "shortswords"],
+    "tools": ["Choose one type of artisan's tools or one musical instrument"],
+    "saving_throws": ["Strength", "Dexterity"],
+    "skills": {
+      "choose_from": ["Acrobatics", "Athletics", "History", "Insight", "Religion", "Stealth"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a shortsword or (b) any simple weapon",
+    "(a) a dungeoneer's pack or (b) an explorer's pack",
+    "10 darts"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Unarmored Defense, Martial Arts", "martial_arts": "1d4", "ki_points": 0, "unarmored_movement": "+0 ft."},
+    "2": {"proficiency_bonus": 2, "features": "Ki, Unarmored Movement", "martial_arts": "1d4", "ki_points": 2, "unarmored_movement": "+10 ft."},
+    "3": {"proficiency_bonus": 2, "features": "Monastic Tradition, Deflect Missiles", "martial_arts": "1d4", "ki_points": 3, "unarmored_movement": "+10 ft."},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement, Slow Fall", "martial_arts": "1d4", "ki_points": 4, "unarmored_movement": "+10 ft."},
+    "5": {"proficiency_bonus": 3, "features": "Extra Attack, Stunning Strike", "martial_arts": "1d6", "ki_points": 5, "unarmored_movement": "+10 ft."},
+    "6": {"proficiency_bonus": 3, "features": "Ki-Empowered Strikes, Monastic Tradition feature", "martial_arts": "1d6", "ki_points": 6, "unarmored_movement": "+15 ft."},
+    "7": {"proficiency_bonus": 3, "features": "Evasion, Stillness of Mind", "martial_arts": "1d6", "ki_points": 7, "unarmored_movement": "+15 ft."},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement", "martial_arts": "1d6", "ki_points": 8, "unarmored_movement": "+15 ft."},
+    "9": {"proficiency_bonus": 4, "features": "Unarmored Movement improvement", "martial_arts": "1d6", "ki_points": 9, "unarmored_movement": "+15 ft."},
+    "10": {"proficiency_bonus": 4, "features": "Purity of Body", "martial_arts": "1d6", "ki_points": 10, "unarmored_movement": "+20 ft."},
+    "11": {"proficiency_bonus": 4, "features": "Monastic Tradition feature", "martial_arts": "1d8", "ki_points": 11, "unarmored_movement": "+20 ft."},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "martial_arts": "1d8", "ki_points": 12, "unarmored_movement": "+20 ft."},
+    "13": {"proficiency_bonus": 5, "features": "Tongue of the Sun and Moon", "martial_arts": "1d8", "ki_points": 13, "unarmored_movement": "+20 ft."},
+    "14": {"proficiency_bonus": 5, "features": "Diamond Soul", "martial_arts": "1d8", "ki_points": 14, "unarmored_movement": "+25 ft."},
+    "15": {"proficiency_bonus": 5, "features": "Timeless Body", "martial_arts": "1d8", "ki_points": 15, "unarmored_movement": "+25 ft."},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "martial_arts": "1d8", "ki_points": 16, "unarmored_movement": "+25 ft."},
+    "17": {"proficiency_bonus": 6, "features": "Monastic Tradition feature", "martial_arts": "1d10", "ki_points": 17, "unarmored_movement": "+25 ft."},
+    "18": {"proficiency_bonus": 6, "features": "Empty Body", "martial_arts": "1d10", "ki_points": 18, "unarmored_movement": "+30 ft."},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "martial_arts": "1d10", "ki_points": 19, "unarmored_movement": "+30 ft."},
+    "20": {"proficiency_bonus": 6, "features": "Perfect Self", "martial_arts": "1d10", "ki_points": 20, "unarmored_movement": "+30 ft."}
+  },
+  "subclasses_title": "Monastic Tradition",
+  "subclasses": [
+    {
+      "name": "Way of the Open Hand",
+      "source": "Player's Handbook",
+      "description": "Monks of the Way of the Open Hand are the ultimate masters of martial arts combat, whether armed or unarmed. They learn techniques to push and trip their opponents, manipulate ki to heal damage to their bodies, and practice advanced meditation that can protect them from harm.",
+      "features_by_level": {
+        "3": ["Open Hand Technique"],
+        "6": ["Wholeness of Body"],
+        "11": ["Tranquility"],
+        "17": ["Quivering Palm"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/paladin.json
+++ b/game_data/classes/paladin.json
@@ -1,0 +1,97 @@
+{
+  "name": "Paladin",
+  "source": "Player's Handbook",
+  "description": "A holy warrior bound to a sacred oath.",
+  "hit_points": {
+    "hit_dice": "1d10 per paladin level",
+    "hp_at_1st_level": "10 + your Constitution modifier",
+    "hp_at_higher_levels": "1d10 (or 6) + your Constitution modifier per paladin level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["light armor", "medium armor", "heavy armor", "shields"],
+    "weapons": ["simple weapons", "martial weapons"],
+    "tools": ["None"],
+    "saving_throws": ["Wisdom", "Charisma"],
+    "skills": {
+      "choose_from": ["Athletics", "Insight", "Intimidation", "Medicine", "Persuasion", "Religion"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a martial weapon and a shield or (b) two martial weapons",
+    "(a) five javelins or (b) any simple melee weapon",
+    "(a) a priest's pack or (b) an explorer's pack",
+    "Chain Mail and a holy symbol"
+  ],
+  "fighting_styles": {
+    "description": "At 2nd level, you adopt a style of fighting as your specialty. Choose one of the following options. You can’t take a Fighting Style option more than once, even if you later get to choose again.",
+    "options": [
+      {
+        "name": "Defense",
+        "description": "While you are wearing armor, you gain a +1 bonus to AC."
+      },
+      {
+        "name": "Dueling",
+        "description": "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon."
+      },
+      {
+        "name": "Great Weapon Fighting",
+        "description": "When you roll a 1 or 2 on a damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the die and must use the new roll. The weapon must have the two-handed or versatile property for you to gain this benefit."
+      },
+      {
+        "name": "Protection",
+        "description": "When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a shield."
+      }
+    ]
+  },
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Divine Sense, Lay on Hands", "spell_slots_1st": 0, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "2": {"proficiency_bonus": 2, "features": "Fighting Style, Spellcasting, Divine Smite", "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "3": {"proficiency_bonus": 2, "features": "Divine Health, Sacred Oath", "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "5": {"proficiency_bonus": 3, "features": "Extra Attack", "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "6": {"proficiency_bonus": 3, "features": "Aura of Protection", "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "7": {"proficiency_bonus": 3, "features": "Sacred Oath feature", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "9": {"proficiency_bonus": 4, "features": "-", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "10": {"proficiency_bonus": 4, "features": "Aura of Courage", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "11": {"proficiency_bonus": 4, "features": "Improved Divine Smite", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "13": {"proficiency_bonus": 5, "features": "-", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0},
+    "14": {"proficiency_bonus": 5, "features": "Cleansing Touch", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0},
+    "15": {"proficiency_bonus": 5, "features": "Sacred Oath feature", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0},
+    "17": {"proficiency_bonus": 6, "features": "-", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1},
+    "18": {"proficiency_bonus": 6, "features": "Aura improvements", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2},
+    "20": {"proficiency_bonus": 6, "features": "Sacred Oath feature", "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2}
+  },
+  "subclasses_title": "Sacred Oath",
+  "subclasses": [
+    {
+      "name": "Oath of Devotion",
+      "source": "Player's Handbook",
+      "description": "The Oath of Devotion binds a paladin to the loftiest ideals of justice, virtue, and order. Sometimes called cavaliers, white knights, or holy warriors, these paladins meet the ideal of the knight in shining armor, acting with honor in pursuit of justice and the greater good.",
+      "tenets": [
+        "Honesty: Don’t lie or cheat. Let your word be your promise.",
+        "Courage: Never fear to act, though caution is wise.",
+        "Compassion: Aid others, protect the weak, and punish those who threaten them. Show mercy to your foes, but temper it with wisdom.",
+        "Honor: Treat others with fairness, and let your honorable deeds be an example to them. Do as much good as possible while causing the least amount of harm.",
+        "Duty: Be responsible for your actions and their consequences, protect those entrusted to your care, and obey those who have just authority over you."
+      ],
+      "oath_spells": {
+        "3": ["Protection from Evil and Good", "Sanctuary"],
+        "5": ["Lesser Restoration", "Zone of Truth"],
+        "9": ["Beacon of Hope", "Dispel Magic"],
+        "13": ["Freedom of Movement", "Guardian of Faith"],
+        "17": ["Commune", "Flame Strike"]
+      },
+      "features_by_level": {
+        "3": ["Channel Divinity: Sacred Weapon", "Channel Divinity: Turn the Unholy"],
+        "7": ["Aura of Devotion"],
+        "15": ["Purity of Spirit"],
+        "20": ["Holy Nimbus"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/ranger.json
+++ b/game_data/classes/ranger.json
@@ -1,0 +1,114 @@
+{
+  "name": "Ranger",
+  "source": "Player's Handbook",
+  "description": "A warrior who uses martial prowess and nature magic to combat threats on the edges of civilization.",
+  "hit_points": {
+    "hit_dice": "1d10 per ranger level",
+    "hp_at_1st_level": "10 + your Constitution modifier",
+    "hp_at_higher_levels": "1d10 (or 6) + your Constitution modifier per ranger level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["light armor", "medium armor", "shields"],
+    "weapons": ["simple weapons", "martial weapons"],
+    "tools": ["None"],
+    "saving_throws": ["Strength", "Dexterity"],
+    "skills": {
+      "choose_from": ["Animal Handling", "Athletics", "Insight", "Investigation", "Nature", "Perception", "Stealth", "Survival"],
+      "count": 3
+    }
+  },
+  "equipment": [
+    "(a) Scale Mail or (b) leather armor",
+    "(a) two shortswords or (b) two simple melee weapons",
+    "(a) a dungeoneer's pack or (b) an explorer's pack",
+    "A longbow and a quiver of 20 arrows"
+  ],
+  "fighting_styles": {
+    "description": "At 2nd level, you adopt a particular style of fighting as your specialty. Choose one of the following options. You can’t take a Fighting Style option more than once, even if you later get to choose again.",
+    "options": [
+      {
+        "name": "Archery",
+        "description": "You gain a +2 bonus to attack rolls you make with ranged weapons."
+      },
+      {
+        "name": "Defense",
+        "description": "While you are wearing armor, you gain a +1 bonus to AC."
+      },
+      {
+        "name": "Dueling",
+        "description": "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon."
+      },
+      {
+        "name": "Two-Weapon Fighting",
+        "description": "When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack."
+      }
+    ]
+  },
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Favored Enemy, Natural Explorer", "spells_known": 0, "spell_slots_1st": 0, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "2": {"proficiency_bonus": 2, "features": "Fighting Style, Spellcasting", "spells_known": 2, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "3": {"proficiency_bonus": 2, "features": "Ranger Archetype, Primeval Awareness", "spells_known": 3, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "spells_known": 3, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "5": {"proficiency_bonus": 3, "features": "Extra Attack", "spells_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "6": {"proficiency_bonus": 3, "features": "Favored Enemy and Natural Explorer improvements", "spells_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "7": {"proficiency_bonus": 3, "features": "Ranger Archetype feature", "spells_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement, Land’s Stride", "spells_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "9": {"proficiency_bonus": 4, "features": "-", "spells_known": 6, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "10": {"proficiency_bonus": 4, "features": "Natural Explorer improvement, Hide in Plain Sight", "spells_known": 6, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "11": {"proficiency_bonus": 4, "features": "Ranger Archetype feature", "spells_known": 7, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "spells_known": 7, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0},
+    "13": {"proficiency_bonus": 5, "features": "-", "spells_known": 8, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0},
+    "14": {"proficiency_bonus": 5, "features": "Favored Enemy improvement, Vanish", "spells_known": 8, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0},
+    "15": {"proficiency_bonus": 5, "features": "Ranger Archetype feature", "spells_known": 9, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "spells_known": 9, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0},
+    "17": {"proficiency_bonus": 6, "features": "-", "spells_known": 10, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1},
+    "18": {"proficiency_bonus": 6, "features": "Feral Senses", "spells_known": 10, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "spells_known": 11, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2},
+    "20": {"proficiency_bonus": 6, "features": "Foe Slayer", "spells_known": 11, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2}
+  },
+  "subclasses_title": "Ranger Archetype",
+  "subclasses": [
+    {
+      "name": "Hunter",
+      "source": "Player's Handbook",
+      "description": "Emulating the Hunter archetype means accepting your place as a bulwark between civilization and the terrors of the wilderness. As you walk the Hunter’s path, you learn specialized techniques for fighting the threats you face.",
+      "features_by_level": {
+        "3": {
+          "name": "Hunter's Prey",
+          "description": "At 3rd level, you gain one of the following features of your choice.",
+          "options": [
+            {"name": "Colossus Slayer", "description": "Your tenacity can wear down the most potent foes. When you hit a creature with a weapon attack, the creature takes an extra 1d8 damage if it’s below its hit point maximum. You can deal this extra damage only once per turn."},
+            {"name": "Giant Killer", "description": "When a Large or larger creature within 5 feet of you hits or misses you with an attack, you can use your reaction to attack that creature immediately after its attack, provided that you can see the creature."},
+            {"name": "Horde Breaker", "description": "Once on each of your turns when you make a weapon attack, you can make another attack with the same weapon against a different creature that is within 5 feet of the original target and within range of your weapon."}
+          ]
+        },
+        "7": {
+          "name": "Defensive Tactics",
+          "description": "At 7th level, you gain one of the following features of your choice.",
+          "options": [
+            {"name": "Escape the Horde", "description": "Opportunity attacks against you are made with disadvantage."},
+            {"name": "Multiattack Defense", "description": "When a creature hits you with an attack, you gain a +4 bonus to AC against all subsequent attacks made by that creature for the rest of the turn."},
+            {"name": "Steel Will", "description": "You have advantage on saving throws against being frightened."}
+          ]
+        },
+        "11": {
+          "name": "Multiattack",
+          "description": "At 11th level, you gain one of the following features of your choice.",
+          "options": [
+            {"name": "Volley", "description": "You can use your action to make a ranged attack against any number of creatures within 10 feet of a point you can see within your weapon’s range. You must have ammunition for each target, as normal, and you make a separate attack roll for each target."},
+            {"name": "Whirlwind Attack", "description": "You can use your action to make a melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target."}
+          ]
+        },
+        "15": {
+          "name": "Superior Hunter's Defense",
+          "description": "At 15th level, you gain one of the following features of your choice.",
+          "options": [
+            {"name": "Evasion", "description": "When you are subjected to an effect, such as a red dragon’s fiery breath or a lightning bolt spell, that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail."},
+            {"name": "Stand Against the Tide", "description": "When a hostile creature misses you with a melee attack, you can use your reaction to force that creature to repeat the same attack against another creature (other than itself) of your choice."},
+            {"name": "Uncanny Dodge", "description": "When an attacker that you can see hits you with an attack, you can use your reaction to halve the attack’s damage against you."}
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/game_data/classes/rogue.json
+++ b/game_data/classes/rogue.json
@@ -1,0 +1,62 @@
+{
+  "name": "Rogue",
+  "source": "Player's Handbook",
+  "description": "A scoundrel who uses stealth and trickery to overcome obstacles and enemies.",
+  "hit_points": {
+    "hit_dice": "1d8 per rogue level",
+    "hp_at_1st_level": "8 + your Constitution modifier",
+    "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per rogue level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["light armor"],
+    "weapons": ["simple weapons", "hand crossbows", "longswords", "rapiers", "shortswords"],
+    "tools": ["thieves' tools"],
+    "saving_throws": ["Dexterity", "Intelligence"],
+    "skills": {
+      "choose_from": ["Acrobatics", "Athletics", "Deception", "Insight", "Intimidation", "Investigation", "Perception", "Performance", "Persuasion", "Sleight of Hand", "Stealth"],
+      "count": 4
+    }
+  },
+  "equipment": [
+    "(a) a rapier or (b) a shortsword",
+    "(a) a shortbow and quiver of 20 arrows or (b) a shortsword",
+    "(a) a burglar's pack, (b) a dungeoneer's pack, or (c) an explorer's pack",
+    "Leather Armor, two daggers, and thieves' tools"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "sneak_attack": "1d6", "features": "Expertise, Sneak Attack, Thieves’ Cant"},
+    "2": {"proficiency_bonus": 2, "sneak_attack": "1d6", "features": "Cunning Action"},
+    "3": {"proficiency_bonus": 2, "sneak_attack": "2d6", "features": "Roguish Archetype"},
+    "4": {"proficiency_bonus": 2, "sneak_attack": "2d6", "features": "Ability Score Improvement"},
+    "5": {"proficiency_bonus": 3, "sneak_attack": "3d6", "features": "Uncanny Dodge"},
+    "6": {"proficiency_bonus": 3, "sneak_attack": "3d6", "features": "Expertise"},
+    "7": {"proficiency_bonus": 3, "sneak_attack": "4d6", "features": "Evasion"},
+    "8": {"proficiency_bonus": 3, "sneak_attack": "4d6", "features": "Ability Score Improvement"},
+    "9": {"proficiency_bonus": 4, "sneak_attack": "5d6", "features": "Roguish Archetype feature"},
+    "10": {"proficiency_bonus": 4, "sneak_attack": "5d6", "features": "Ability Score Improvement"},
+    "11": {"proficiency_bonus": 4, "sneak_attack": "6d6", "features": "Reliable Talent"},
+    "12": {"proficiency_bonus": 4, "sneak_attack": "6d6", "features": "Ability Score Improvement"},
+    "13": {"proficiency_bonus": 5, "sneak_attack": "7d6", "features": "Roguish Archetype feature"},
+    "14": {"proficiency_bonus": 5, "sneak_attack": "7d6", "features": "Blindsense"},
+    "15": {"proficiency_bonus": 5, "sneak_attack": "8d6", "features": "Slippery Mind"},
+    "16": {"proficiency_bonus": 5, "sneak_attack": "8d6", "features": "Ability Score Improvement"},
+    "17": {"proficiency_bonus": 6, "sneak_attack": "9d6", "features": "Roguish Archetype feature"},
+    "18": {"proficiency_bonus": 6, "sneak_attack": "9d6", "features": "Elusive"},
+    "19": {"proficiency_bonus": 6, "sneak_attack": "10d6", "features": "Ability Score Improvement"},
+    "20": {"proficiency_bonus": 6, "sneak_attack": "10d6", "features": "Stroke of Luck"}
+  },
+  "subclasses_title": "Roguish Archetype",
+  "subclasses": [
+    {
+      "name": "Thief",
+      "source": "Player's Handbook",
+      "description": "You hone your skills in the larcenous arts. Burglars, bandits, cutpurses, and other criminals typically follow this archetype, but so do rogues who prefer to think of themselves as professional treasure seekers, explorers, delvers, and investigators.",
+      "features_by_level": {
+        "3": ["Fast Hands", "Second-Story Work"],
+        "9": ["Supreme Sneak"],
+        "13": ["Use Magic Device"],
+        "17": ["Thief’s Reflexes"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/sorcerer.json
+++ b/game_data/classes/sorcerer.json
@@ -1,0 +1,84 @@
+{
+  "name": "Sorcerer",
+  "source": "Player's Handbook",
+  "description": "A spellcaster who draws on inherent magic from a gift or bloodline.",
+  "hit_points": {
+    "hit_dice": "1d6 per sorcerer level",
+    "hp_at_1st_level": "6 + your Constitution modifier",
+    "hp_at_higher_levels": "1d6 (or 4) + your Constitution modifier per sorcerer level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["None"],
+    "weapons": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
+    "tools": ["None"],
+    "saving_throws": ["Constitution", "Charisma"],
+    "skills": {
+      "choose_from": ["Arcana", "Deception", "Insight", "Intimidation", "Persuasion", "Religion"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a light crossbow and 20 bolts or (b) any simple weapon",
+    "(a) a component pouch or (b) an arcane focus",
+    "(a) a dungeoneer's pack or (b) an explorer's pack",
+    "Two daggers"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "sorcery_points": 0, "features": "Spellcasting, Sorcerous Origin", "cantrips_known": 4, "spells_known": 2, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "2": {"proficiency_bonus": 2, "sorcery_points": 2, "features": "Font of Magic", "cantrips_known": 4, "spells_known": 3, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "3": {"proficiency_bonus": 2, "sorcery_points": 3, "features": "Metamagic", "cantrips_known": 4, "spells_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "4": {"proficiency_bonus": 2, "sorcery_points": 4, "features": "Ability Score Improvement", "cantrips_known": 5, "spells_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "5": {"proficiency_bonus": 3, "sorcery_points": 5, "features": "-", "cantrips_known": 5, "spells_known": 6, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "6": {"proficiency_bonus": 3, "sorcery_points": 6, "features": "Sorcerous Origin feature", "cantrips_known": 5, "spells_known": 7, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "7": {"proficiency_bonus": 3, "sorcery_points": 7, "features": "-", "cantrips_known": 5, "spells_known": 8, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "8": {"proficiency_bonus": 3, "sorcery_points": 8, "features": "Ability Score Improvement", "cantrips_known": 5, "spells_known": 9, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "9": {"proficiency_bonus": 4, "sorcery_points": 9, "features": "-", "cantrips_known": 5, "spells_known": 10, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "10": {"proficiency_bonus": 4, "sorcery_points": 10, "features": "Metamagic", "cantrips_known": 6, "spells_known": 11, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "11": {"proficiency_bonus": 4, "sorcery_points": 11, "features": "-", "cantrips_known": 6, "spells_known": 12, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "12": {"proficiency_bonus": 4, "sorcery_points": 12, "features": "Ability Score Improvement", "cantrips_known": 6, "spells_known": 12, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "13": {"proficiency_bonus": 5, "sorcery_points": 13, "features": "-", "cantrips_known": 6, "spells_known": 13, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "14": {"proficiency_bonus": 5, "sorcery_points": 14, "features": "Sorcerous Origin feature", "cantrips_known": 6, "spells_known": 13, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "15": {"proficiency_bonus": 5, "sorcery_points": 15, "features": "-", "cantrips_known": 6, "spells_known": 14, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "16": {"proficiency_bonus": 5, "sorcery_points": 16, "features": "Ability Score Improvement", "cantrips_known": 6, "spells_known": 14, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "17": {"proficiency_bonus": 6, "sorcery_points": 17, "features": "Metamagic", "cantrips_known": 6, "spells_known": 15, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "18": {"proficiency_bonus": 6, "sorcery_points": 18, "features": "Sorcerous Origin feature", "cantrips_known": 6, "spells_known": 15, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "19": {"proficiency_bonus": 6, "sorcery_points": 19, "features": "Ability Score Improvement", "cantrips_known": 6, "spells_known": 15, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "20": {"proficiency_bonus": 6, "sorcery_points": 20, "features": "Sorcerous Restoration", "cantrips_known": 6, "spells_known": 15, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 2, "spell_slots_8th": 1, "spell_slots_9th": 1}
+  },
+  "metamagic_options": [
+    {"name": "Careful Spell", "description": "When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell’s full force. To do so, you spend 1 sorcery point and choose a number of those creatures up to your Charisma modifier (minimum of one creature). A chosen creature automatically succeeds on its saving throw against the spell."},
+    {"name": "Distant Spell", "description": "When you cast a spell that has a range of 5 feet or greater, you can spend 1 sorcery point to double the range of the spell. When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet."},
+    {"name": "Empowered Spell", "description": "When you roll damage for a spell, you can spend 1 sorcery point to reroll a number of the damage dice up to your Charisma modifier (minimum of one). You must use the new rolls. You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell."},
+    {"name": "Extended Spell", "description": "When you cast a spell that has a duration of 1 minute or longer, you can spend 1 sorcery point to double its duration, to a maximum duration of 24 hours."},
+    {"name": "Heightened Spell", "description": "When you cast a spell that forces a creature to make a saving throw to resist its effects, you can spend 3 sorcery points to give one target of the spell disadvantage on its first saving throw made against the spell."},
+    {"name": "Quickened Spell", "description": "When you cast a spell that has a casting time of 1 action, you can spend 2 sorcery points to change the casting time to 1 bonus action for this casting."},
+    {"name": "Subtle Spell", "description": "When you cast a spell, you can spend 1 sorcery point to cast it without any somatic or verbal components."},
+    {"name": "Twinned Spell", "description": "When you cast a spell that targets only one creature and doesn’t have a range of self, you can spend a number of sorcery points equal to the spell’s level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip). To be eligible, a spell must be incapable of targeting more than one creature at the spell’s current level."}
+  ],
+  "subclasses_title": "Sorcerous Origin",
+  "subclasses": [
+    {
+      "name": "Draconic Bloodline",
+      "source": "Player's Handbook",
+      "description": "Your innate magic comes from draconic magic that was mingled with your blood or that of your ancestors. Most often, sorcerers with this origin trace their descent back to a mighty sorcerer of ancient times who made a bargain with a dragon or who might even have claimed a dragon parent.",
+      "dragon_ancestor_options": [
+        {"dragon": "Black", "damage_type": "Acid"},
+        {"dragon": "Blue", "damage_type": "Lightning"},
+        {"dragon": "Brass", "damage_type": "Fire"},
+        {"dragon": "Bronze", "damage_type": "Lightning"},
+        {"dragon": "Copper", "damage_type": "Acid"},
+        {"dragon": "Gold", "damage_type": "Fire"},
+        {"dragon": "Green", "damage_type": "Poison"},
+        {"dragon": "Red", "damage_type": "Fire"},
+        {"dragon": "Silver", "damage_type": "Cold"},
+        {"dragon": "White", "damage_type": "Cold"}
+      ],
+      "features_by_level": {
+        "1": ["Dragon Ancestor", "Draconic Resilience"],
+        "6": ["Elemental Affinity"],
+        "14": ["Dragon Wings"],
+        "18": ["Draconic Presence"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/warlock.json
+++ b/game_data/classes/warlock.json
@@ -1,0 +1,117 @@
+{
+  "name": "Warlock",
+  "source": "Player's Handbook",
+  "description": "A wielder of magic that is derived from a bargain with an extraplanar entity.",
+  "hit_points": {
+    "hit_dice": "1d8 per warlock level",
+    "hp_at_1st_level": "8 + your Constitution modifier",
+    "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per warlock level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["light armor"],
+    "weapons": ["simple weapons"],
+    "tools": ["None"],
+    "saving_throws": ["Wisdom", "Charisma"],
+    "skills": {
+      "choose_from": ["Arcana", "Deception", "History", "Intimidation", "Investigation", "Nature", "Religion"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a light crossbow and 20 bolts or (b) any simple weapon",
+    "(a) a component pouch or (b) an arcane focus",
+    "(a) a scholar's pack or (b) a dungeoneer's pack",
+    "Leather Armor, any simple weapon, and two daggers"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Otherworldly Patron, Pact Magic", "cantrips_known": 2, "spells_known": 2, "spell_slots": 1, "slot_level": "1st", "invocations_known": 0},
+    "2": {"proficiency_bonus": 2, "features": "Eldritch Invocations", "cantrips_known": 2, "spells_known": 3, "spell_slots": 2, "slot_level": "1st", "invocations_known": 2},
+    "3": {"proficiency_bonus": 2, "features": "Pact Boon", "cantrips_known": 2, "spells_known": 4, "spell_slots": 2, "slot_level": "2nd", "invocations_known": 2},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "cantrips_known": 3, "spells_known": 5, "spell_slots": 2, "slot_level": "2nd", "invocations_known": 2},
+    "5": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 3, "spells_known": 6, "spell_slots": 2, "slot_level": "3rd", "invocations_known": 3},
+    "6": {"proficiency_bonus": 3, "features": "Otherworldly Patron feature", "cantrips_known": 3, "spells_known": 7, "spell_slots": 2, "slot_level": "3rd", "invocations_known": 3},
+    "7": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 3, "spells_known": 8, "spell_slots": 2, "slot_level": "4th", "invocations_known": 4},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement", "cantrips_known": 3, "spells_known": 9, "spell_slots": 2, "slot_level": "4th", "invocations_known": 4},
+    "9": {"proficiency_bonus": 4, "features": "-", "cantrips_known": 3, "spells_known": 10, "spell_slots": 2, "slot_level": "5th", "invocations_known": 5},
+    "10": {"proficiency_bonus": 4, "features": "Otherworldly Patron feature", "cantrips_known": 4, "spells_known": 10, "spell_slots": 2, "slot_level": "5th", "invocations_known": 5},
+    "11": {"proficiency_bonus": 4, "features": "Mystic Arcanum (6th level)", "cantrips_known": 4, "spells_known": 11, "spell_slots": 3, "slot_level": "5th", "invocations_known": 5},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "cantrips_known": 4, "spells_known": 11, "spell_slots": 3, "slot_level": "5th", "invocations_known": 6},
+    "13": {"proficiency_bonus": 5, "features": "Mystic Arcanum (7th level)", "cantrips_known": 4, "spells_known": 12, "spell_slots": 3, "slot_level": "5th", "invocations_known": 6},
+    "14": {"proficiency_bonus": 5, "features": "Otherworldly Patron feature", "cantrips_known": 4, "spells_known": 12, "spell_slots": 3, "slot_level": "5th", "invocations_known": 6},
+    "15": {"proficiency_bonus": 5, "features": "Mystic Arcanum (8th level)", "cantrips_known": 4, "spells_known": 13, "spell_slots": 3, "slot_level": "5th", "invocations_known": 7},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "cantrips_known": 4, "spells_known": 13, "spell_slots": 3, "slot_level": "5th", "invocations_known": 7},
+    "17": {"proficiency_bonus": 6, "features": "Mystic Arcanum (9th level)", "cantrips_known": 4, "spells_known": 14, "spell_slots": 4, "slot_level": "5th", "invocations_known": 7},
+    "18": {"proficiency_bonus": 6, "features": "-", "cantrips_known": 4, "spells_known": 14, "spell_slots": 4, "slot_level": "5th", "invocations_known": 8},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "cantrips_known": 4, "spells_known": 15, "spell_slots": 4, "slot_level": "5th", "invocations_known": 8},
+    "20": {"proficiency_bonus": 6, "features": "Eldritch Master", "cantrips_known": 4, "spells_known": 15, "spell_slots": 4, "slot_level": "5th", "invocations_known": 8}
+  },
+  "pact_boon_options": [
+    {
+      "name": "Pact of the Chain",
+      "description": "You learn the find familiar spell and can cast it as a ritual. The spell doesn’t count against your number of spells known. When you cast the spell, you can choose one of the normal forms for your familiar or one of the following special forms: imp, pseudodragon, quasit, or sprite. Additionally, when you take the Attack action, you can forgo one of your own attacks to allow your familiar to make one attack of its own with its reaction."
+    },
+    {
+      "name": "Pact of the Blade",
+      "description": "You can use your action to create a pact weapon in your empty hand. You can choose the form that this melee weapon takes each time you create it. You are proficient with it while you wield it. This weapon counts as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage. Your pact weapon disappears if it is more than 5 feet away from you for 1 minute or more. It also disappears if you use this feature again, if you dismiss the weapon (no action required), or if you die. You can transform one Magic Weapon into your pact weapon by performing a special ritual while you hold the weapon. You perform the ritual over the course of 1 hour, which can be done during a short rest. You can then dismiss the weapon, shunting it into an extradimensional space, and it appears whenever you create your pact weapon thereafter. You can’t affect an artifact or a sentient weapon in this way. The weapon ceases being your pact weapon if you die, if you perform the 1-hour ritual on a different weapon, or if you use a 1-hour ritual to break your bond to it. The weapon appears at your feet if it is in the extradimensional space when the bond breaks."
+    },
+    {
+      "name": "Pact of the Tome",
+      "description": "Your patron gives you a grimoire called a Book of Shadows. When you gain this feature, choose three cantrips from any class’s spell list (the three needn’t be from the same list). While the book is on your person, you can cast those cantrips at will. They don’t count against your number of cantrips known. If they don’t appear on the warlock spell list, they are nonetheless warlock spells for you. If you lose your Book of Shadows, you can perform a 1-hour ceremony to receive a replacement from your patron. This ceremony can be performed during a short or long rest, and it destroys the previous book. The book turns to ash when you die."
+    }
+  ],
+  "eldritch_invocations": [
+    {"name": "Agonizing Blast", "prerequisite": "eldritch blast cantrip", "description": "When you cast eldritch blast, add your Charisma modifier to the damage it deals on a hit."},
+    {"name": "Armor of Shadows", "prerequisite": "None", "description": "You can cast mage armor on yourself at will, without expending a spell slot or material components."},
+    {"name": "Ascendant Step", "prerequisite": "9th level", "description": "You can cast levitate on yourself at will, without expending a spell slot or material components."},
+    {"name": "Beast Speech", "prerequisite": "None", "description": "You can cast speak with animals at will, without expending a spell slot."},
+    {"name": "Beguiling Influence", "prerequisite": "None", "description": "You gain proficiency in the Deception and Persuasion skills."},
+    {"name": "Bewitching Whispers", "prerequisite": "7th level", "description": "You can cast compulsion once using a warlock spell slot. You can’t do so again until you finish a long rest."},
+    {"name": "Book of Ancient Secrets", "prerequisite": "Pact of the Tome feature", "description": "You can now inscribe magical rituals in your Book of Shadows. Choose two 1st-level spells that have the ritual tag from any class’s spell list. The spells appear in the book and don’t count against the number of spells you know. With your Book of Shadows in hand, you can cast the chosen spells as rituals. You can’t cast the spells except as rituals, unless you’ve learned them by some other means. You can also cast a warlock spell you know as a ritual if it has the ritual tag. On your adventures, you can add other ritual spells to your Book of Shadows. When you find such a spell, you can add it to the book if the spell’s level is equal to or less than half your warlock level (rounded up) and if you can spare the time to transcribe the spell. For each level of the spell, the transcription process takes 2 hours and costs 50 gp for the rare inks needed to inscribe it."},
+    {"name": "Chains of Carceri", "prerequisite": "15th level, Pact of the Chain feature", "description": "You can cast hold monster at will—targeting a celestial, fiend, or elemental—without expending a spell slot or material components. You must finish a long rest before you can use this invocation on the same creature again."},
+    {"name": "Devil’s Sight", "prerequisite": "None", "description": "You can see normally in darkness, both magical and nonmagical, to a distance of 120 feet."},
+    {"name": "Dreadful Word", "prerequisite": "7th level", "description": "You can cast confusion once using a warlock spell slot. You can’t do so again until you finish a long rest."},
+    {"name": "Eldritch Sight", "prerequisite": "None", "description": "You can cast detect magic at will, without expending a spell slot."},
+    {"name": "Eldritch Spear", "prerequisite": "eldritch blast cantrip", "description": "When you cast eldritch blast, its range is 300 feet."},
+    {"name": "Eyes of the Rune Keeper", "prerequisite": "None", "description": "You can read all writing."},
+    {"name": "Fiendish Vigor", "prerequisite": "None", "description": "You can cast false life on yourself at will as a 1st-level spell, without expending a spell slot or material components."},
+    {"name": "Gaze of Two Minds", "prerequisite": "None", "description": "You can use your action to touch a willing humanoid and perceive through its senses until the end of your next turn. As long as the creature is on the same plane of existence as you, you can use your action on subsequent turns to maintain this connection, extending the duration until the end of your next turn. While perceiving through the other creature’s senses, you benefit from any special senses possessed by that creature, and you are blinded and deafened to your own surroundings."},
+    {"name": "Lifedrinker", "prerequisite": "12th level, Pact of the Blade feature", "description": "When you hit a creature with your pact weapon, the creature takes extra necrotic damage equal to your Charisma modifier (minimum 1)."},
+    {"name": "Mask of Many Faces", "prerequisite": "None", "description": "You can cast disguise self at will, without expending a spell slot."},
+    {"name": "Master of Myriad Forms", "prerequisite": "15th level", "description": "You can cast alter self at will, without expending a spell slot."},
+    {"name": "Minions of Chaos", "prerequisite": "9th level", "description": "You can cast conjure elemental once using a warlock spell slot. You can’t do so again until you finish a long rest."},
+    {"name": "Mire the Mind", "prerequisite": "5th level", "description": "You can cast slow once using a warlock spell slot. You can’t do so again until you finish a long rest."},
+    {"name": "Misty Visions", "prerequisite": "None", "description": "You can cast silent image at will, without expending a spell slot or material components."},
+    {"name": "One with Shadows", "prerequisite": "5th level", "description": "When you are in an area of dim light or darkness, you can use your action to become invisible until you move or take an action or a reaction."},
+    {"name": "Otherworldly Leap", "prerequisite": "9th level", "description": "You can cast jump on yourself at will, without expending a spell slot or material components."},
+    {"name": "Repelling Blast", "prerequisite": "eldritch blast cantrip", "description": "When you hit a creature with eldritch blast, you can push the creature up to 10 feet away from you in a straight line."},
+    {"name": "Sculptor of Flesh", "prerequisite": "7th level", "description": "You can cast polymorph once using a warlock spell slot. You can’t do so again until you finish a long rest."},
+    {"name": "Sign of Ill Omen", "prerequisite": "5th level", "description": "You can cast bestow curse once using a warlock spell slot. You can’t do so again until you finish a long rest."},
+    {"name": "Thief of Five Fates", "prerequisite": "None", "description": "You can cast bane once using a warlock spell slot. You can’t do so again until you finish a long rest."},
+    {"name": "Thirsting Blade", "prerequisite": "5th level, Pact of the Blade feature", "description": "You can attack with your pact weapon twice, instead of once, whenever you take the Attack action on your turn."},
+    {"name": "Visions of Distant Realms", "prerequisite": "15th level", "description": "You can cast arcane eye at will, without expending a spell slot."},
+    {"name": "Voice of the Chain Master", "prerequisite": "Pact of the Chain feature", "description": "You can communicate telepathically with your familiar and perceive through your familiar’s senses as long as you are on the same plane of existence. Additionally, while perceiving through your familiar’s senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech."},
+    {"name": "Whispers of the Grave", "prerequisite": "9th level", "description": "You can cast speak with dead at will, without expending a spell slot."},
+    {"name": "Witch Sight", "prerequisite": "15th level", "description": "You can see the true form of any shapechanger or creature concealed by illusion or transmutation magic while the creature is within 30 feet of you and within line of sight."}
+  ],
+  "subclasses_title": "Otherworldly Patron",
+  "subclasses": [
+    {
+      "name": "The Fiend",
+      "source": "Player's Handbook",
+      "description": "You have made a pact with a fiend from the lower planes of existence, a being whose aims are evil, even if you strive against those aims. Such beings desire the corruption or destruction of all things, ultimately including you.",
+      "expanded_spell_list": {
+        "1": ["Burning Hands", "Command"],
+        "2": ["Blindness/Deafness", "Scorching Ray"],
+        "3": ["Fireball", "Stinking Cloud"],
+        "4": ["Fire Shield", "Wall of Fire"],
+        "5": ["Flame Strike", "Hallow"]
+      },
+      "features_by_level": {
+        "1": ["Dark One’s Blessing"],
+        "6": ["Dark One’s Own Luck"],
+        "10": ["Fiendish Resilience"],
+        "14": ["Hurl Through Hell"]
+      }
+    }
+  ]
+}

--- a/game_data/classes/wizard.json
+++ b/game_data/classes/wizard.json
@@ -1,0 +1,62 @@
+{
+  "name": "Wizard",
+  "source": "Player's Handbook",
+  "description": "A scholarly magic-user capable of manipulating the structures of reality.",
+  "hit_points": {
+    "hit_dice": "1d6 per wizard level",
+    "hp_at_1st_level": "6 + your Constitution modifier",
+    "hp_at_higher_levels": "1d6 (or 4) + your Constitution modifier per wizard level after 1st"
+  },
+  "proficiencies": {
+    "armor": ["None"],
+    "weapons": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
+    "tools": ["None"],
+    "saving_throws": ["Intelligence", "Wisdom"],
+    "skills": {
+      "choose_from": ["Arcana", "History", "Insight", "Investigation", "Medicine", "Religion"],
+      "count": 2
+    }
+  },
+  "equipment": [
+    "(a) a quarterstaff or (b) a dagger",
+    "(a) a component pouch or (b) an arcane focus",
+    "(a) a scholar's pack or (b) an explorer's pack",
+    "A spellbook"
+  ],
+  "class_table": {
+    "1": {"proficiency_bonus": 2, "features": "Spellcasting, Arcane Recovery", "cantrips_known": 3, "spell_slots_1st": 2, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "2": {"proficiency_bonus": 2, "features": "Arcane Tradition", "cantrips_known": 3, "spell_slots_1st": 3, "spell_slots_2nd": 0, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "3": {"proficiency_bonus": 2, "features": "-", "cantrips_known": 3, "spell_slots_1st": 4, "spell_slots_2nd": 2, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "4": {"proficiency_bonus": 2, "features": "Ability Score Improvement", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 0, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "5": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 2, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "6": {"proficiency_bonus": 3, "features": "Arcane Tradition feature", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 0, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "7": {"proficiency_bonus": 3, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 1, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "8": {"proficiency_bonus": 3, "features": "Ability Score Improvement", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 2, "spell_slots_5th": 0, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "9": {"proficiency_bonus": 4, "features": "-", "cantrips_known": 4, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 1, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "10": {"proficiency_bonus": 4, "features": "Arcane Tradition feature", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 0, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "11": {"proficiency_bonus": 4, "features": "-", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "12": {"proficiency_bonus": 4, "features": "Ability Score Improvement", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 0, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "13": {"proficiency_bonus": 5, "features": "-", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "14": {"proficiency_bonus": 5, "features": "Arcane Tradition feature", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 0, "spell_slots_9th": 0},
+    "15": {"proficiency_bonus": 5, "features": "-", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "16": {"proficiency_bonus": 5, "features": "Ability Score Improvement", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 0},
+    "17": {"proficiency_bonus": 6, "features": "-", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 2, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "18": {"proficiency_bonus": 6, "features": "Spell Mastery", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 1, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "19": {"proficiency_bonus": 6, "features": "Ability Score Improvement", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 1, "spell_slots_8th": 1, "spell_slots_9th": 1},
+    "20": {"proficiency_bonus": 6, "features": "Signature Spell", "cantrips_known": 5, "spell_slots_1st": 4, "spell_slots_2nd": 3, "spell_slots_3rd": 3, "spell_slots_4th": 3, "spell_slots_5th": 3, "spell_slots_6th": 2, "spell_slots_7th": 2, "spell_slots_8th": 1, "spell_slots_9th": 1}
+  },
+  "subclasses_title": "Arcane Tradition",
+  "subclasses": [
+    {
+      "name": "School of Evocation",
+      "source": "Player's Handbook",
+      "description": "You focus your study on magic that creates powerful elemental effects such as bitter cold, searing flame, rolling thunder, crackling lightning, and burning acid. Some evokers find employment in military forces, serving as artillery to blast enemy armies from afar. Others use their spectacular power to protect the weak, while some seek their own gain as bandits, adventurers, or aspiring tyrants.",
+      "features_by_level": {
+        "2": ["Evocation Savant", "Sculpt Spells"],
+        "6": ["Potent Cantrip"],
+        "10": ["Empowered Evocation"],
+        "14": ["Overchannel"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
… Armorer, and Artillerist).

This commit introduces the Artificer class and its first three published subclasses: Alchemist, Armorer, and Artillerist.

Here's what I did:
- Created `game_data/classes/artificer.json`.
- Populated `artificer.json` with core class features, proficiencies, equipment, and the class progression table.
- Gathered data for the Alchemist, Armorer, and Artillerist subclasses from dnd5e.wikidot.com.
- Added these subclasses to `artificer.json`, including their specific spells (where applicable) and features by level.

This is part of the broader goal to incorporate all official D&D 5e classes and subclasses. Next, I'll add the Battle Smith subclass for the Artificer. After that, I'll focus on adding expansion subclasses for other classes.