### PR TITLE
Improve town view accessibility

### DIFF
--- a/main_game.html
+++ b/main_game.html
@@ -57,7 +57,7 @@
             <button id="action-inventory" class="action-button">View Inventory</button>
             <button id="action-skills" class="action-button">Skills</button> <!-- Placeholder, as in previous JS -->
             <button id="action-enter-town" class="action-button" style="display: none;">Enter Town</button>
-            <button id="action-open-town-view" class="action-button" style="display: none;">Town View</button>
+            <button id="action-open-town-view" class="action-button">Town View</button>
             <!-- More actions can be added here or dynamically by main_game.js -->
         </div>
 

--- a/main_game.js
+++ b/main_game.js
@@ -91,7 +91,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (openTownViewButton) {
             const hasTown = Boolean(gameState.current_town_id);
-            openTownViewButton.style.display = hasTown ? 'inline-block' : 'none';
+            openTownViewButton.disabled = !hasTown;
+            openTownViewButton.title = hasTown ? '' : 'No town discovered yet.';
         }
         // Add logic for other contextual buttons here if needed
 
@@ -186,13 +187,21 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log("Enter Town button clicked. Sending 'enter town' action to backend.");
         performGameAction("enter town");
     }
-    function handleOpenTownView() {
+    async function handleOpenTownView() {
         if (!gameState || !gameState.current_town_id) {
             console.warn("No town ID available for town view navigation.");
             return;
         }
-        sessionStorage.setItem('currentTownId', gameState.current_town_id);
-        window.location.href = 'town_view.html';
+        try {
+            const resp = await fetch('town_view.html', { method: 'HEAD' });
+            if (!resp.ok) throw new Error(`town_view.html unreachable: ${resp.status}`);
+            const url = new URL('town_view.html', window.location.href);
+            url.searchParams.set('town', gameState.current_town_id);
+            window.location.href = url.toString();
+        } catch (err) {
+            console.error('Failed to load town view:', err);
+            addMessage('Error: Town view could not be loaded.');
+        }
     }
 
     // --- Event Listeners ---

--- a/tests/town_view.test.js
+++ b/tests/town_view.test.js
@@ -7,16 +7,8 @@ const html = fs.readFileSync(path.join(process.cwd(), 'town_view.html'), 'utf8')
 const js = fs.readFileSync(path.join(process.cwd(), 'town_view.js'), 'utf8');
 
 test('renderTown attaches click handlers', async () => {
-  const dom = new JSDOM(html, { runScripts: 'dangerously' });
+  const dom = new JSDOM(html, { runScripts: 'dangerously', url: 'http://localhost/town_view.html?town=test_town_id' });
   const { window } = dom;
-  Object.defineProperty(window, 'sessionStorage', {
-    value: {
-      getItem: () => null,
-      setItem: () => {},
-    },
-    configurable: true,
-  });
-  global.sessionStorage = window.sessionStorage;
   window.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,

--- a/town_view.html
+++ b/town_view.html
@@ -27,6 +27,8 @@
 
     <div id="town-error"></div>
 
+    <button id="back-to-game">Return to Game</button>
+
     <script type="module" src="town_view.js"></script>
 </body>
 </html>

--- a/town_view.js
+++ b/town_view.js
@@ -6,17 +6,27 @@ document.addEventListener('DOMContentLoaded', () => {
     const townMapContainer = document.getElementById('town-map-container');
     const townInfoPanel = document.getElementById('town-info');
     const errorPanel = document.getElementById('town-error');
+    const backButton = document.getElementById('back-to-game');
 
     const defaultEnvironment = 'plains';
     let selectedEnvironment = sessionStorage.getItem('currentEnvironment') || defaultEnvironment;
 
     if (!townMapContainer) {
         console.error("Town View: #town-map-container not found.");
-        // Potentially update a general error div if one exists on town_view.html
+        if (errorPanel) {
+            errorPanel.textContent = "Town map container missing; cannot display town view.";
+            errorPanel.style.color = 'red';
+        }
         return;
     }
     if (!townInfoPanel) {
         console.warn("Town View: #town-info panel not found.");
+        if (errorPanel) {
+            const p = document.createElement('p');
+            p.textContent = 'Town info panel missing.';
+            p.style.color = 'orange';
+            errorPanel.appendChild(p);
+        }
     }
 
     /**
@@ -41,8 +51,11 @@ document.addEventListener('DOMContentLoaded', () => {
             return data;
         } catch (error) {
             console.error("Failed to fetch real town data:", error);
+            if (errorPanel) {
+                errorPanel.textContent = `Failed to load town data: ${error.message}`;
+                errorPanel.style.color = 'red';
+            }
             console.log(`Using hardcoded sample town data for townId: ${townId} instead.`);
-            // Return a more detailed sample object
             return {
                 name: townId === "default_error_town" ? "ErrorTown" : `Sample Town (${townId})`,
                 environment_type: environment,
@@ -103,21 +116,13 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    // --- SessionStorage Logic for Town ID (as per subtask instructions) ---
-    const townIdFromSession = sessionStorage.getItem('currentTownId');
-    let effectiveTownId = 'test_town_id'; // Fallback default
-
-    if (townIdFromSession) {
-        effectiveTownId = townIdFromSession;
-        console.log(`Town View: Found townId in sessionStorage: ${effectiveTownId}`);
-        // Clean up the sessionStorage item
-        sessionStorage.removeItem('currentTownId');
-        console.log("Town View: Removed currentTownId from sessionStorage.");
-    } else {
-        console.warn(`Town View: No currentTownId in sessionStorage. Using fallback: ${effectiveTownId}.`);
+    const params = new URLSearchParams(window.location.search);
+    let effectiveTownId = params.get('town') || 'test_town_id';
+    if (!params.get('town')) {
+        console.warn(`Town View: No town ID in URL. Using fallback: ${effectiveTownId}.`);
         if (townInfoPanel) {
             const p = document.createElement('p');
-            p.style.color = "orange";
+            p.style.color = 'orange';
             p.textContent = `INFO: No specific town ID was passed. Displaying data for default town ('${effectiveTownId}').`;
             townInfoPanel.prepend(p);
         }
@@ -133,6 +138,12 @@ document.addEventListener('DOMContentLoaded', () => {
             errorPanel.style.color = 'red';
         }
     });
+
+    if (backButton) {
+        backButton.addEventListener('click', () => {
+            window.location.href = 'main_game.html';
+        });
+    }
 
     window.__townView = { fetchTownData, renderTown, handleBuildingClick };
 });


### PR DESCRIPTION
## Summary
- keep Town View button visible
- disable the Town View button until the player discovers a town
- verify `town_view.html` is reachable before navigating
- pass the town id via query string
- show a Return to Game button in `town_view.html`
- surface errors for missing elements or failed fetches
- adjust tests for new query-string behavior

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b400be214832fa9ed47bebde6d65d