### PR TITLE
Implement town view access improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,8 @@ def initialize_player_state():
         "current_location": "Mysterious Forest Clearing",
         "location_description": "A quiet clearing surrounded by ancient, whispering trees. Paths lead north and east.",
         "inventory": [], # List of item names or objects
-        "available_actions": ["explore", "look around", "inventory"], # Actions available at current location
+        "available_actions": ["explore", "look around", "inventory", "enter town"], # Actions available at current location
+        "current_town_id": "starting_town",
         "messages": ["Welcome to the adventure! (Recovered Session)"] # Log of messages for the player
     }
 
@@ -341,6 +342,9 @@ def handle_game_action():
         response_data['current_town_id'] = game_state['current_town_id'] # Ensure response has it
         response_data['trigger_town_navigation'] = True # Add trigger only to the response
         # Note: available_actions might change once "in town", handled by subsequent state or specific town API
+    elif action == "leave town":
+        message = "You leave the town and return to the wilds."
+        game_state.pop('current_town_id', None)
     else:
         message = f"Action '{action}' is not recognized or currently available."
 
@@ -360,6 +364,16 @@ def handle_game_action():
     session.modified = True
 
     return jsonify(response_data) # Return the response_data, which includes the one-time trigger if set
+
+
+@app.route('/api/game/leave_town', methods=['POST'])
+def leave_town():
+    if 'game_state' not in session:
+        session['game_state'] = initialize_player_state()
+    game_state = session['game_state']
+    game_state.pop('current_town_id', None)
+    session.modified = True
+    return jsonify(game_state)
 
 # --- Gemini API Proxy (for local development) ---
 @app.route('/api/gemini', methods=['POST'])

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             <button id="open-party" class="mt-2 bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 ml-2">Party</button>
             <button id="open-glossary" class="mt-2 bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 ml-2">Glossary</button>
             <button id="main-menu-btn" class="mt-2 bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 ml-2">Main Menu</button>
+            <button id="open-town-view-index" class="mt-2 bg-gray-700 hover:bg-gray-600 text-white rounded px-3 py-1 ml-2">Town View</button>
         </header>
 
         <main class="flex-grow grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -664,9 +665,16 @@ function openInventory() {
                document.getElementById('companion-overlay').classList.add('hidden');
            }
 
-            function openGlossary() {
-                document.getElementById('glossary-overlay').classList.remove('hidden');
-            }
+           function openGlossary() {
+               document.getElementById('glossary-overlay').classList.remove('hidden');
+           }
+
+           function openTownViewFromIndex() {
+               const townId = sessionStorage.getItem('currentTownId');
+               const url = new URL('town_view.html', window.location.href);
+               if (townId) url.searchParams.set('town', townId);
+               window.location.href = url.toString();
+           }
 
             function closeGlossary() {
                 document.getElementById('glossary-overlay').classList.add('hidden');
@@ -679,6 +687,7 @@ function openInventory() {
            document.getElementById('close-companion').addEventListener('click', closeCompanion);
            document.getElementById('open-glossary').addEventListener('click', openGlossary);
            document.getElementById('close-glossary').addEventListener('click', closeGlossary);
+           document.getElementById('open-town-view-index').addEventListener('click', openTownViewFromIndex);
            // Expose game globally so buttons can access it
             window.game = game;
             window.gameState = gameState;

--- a/main_game.css
+++ b/main_game.css
@@ -167,6 +167,12 @@ h2 {
     margin-bottom: 0;
 }
 
+.action-button.disabled {
+    opacity: 0.5;
+    filter: grayscale(100%);
+    cursor: not-allowed;
+}
+
 /* Responsive adjustments for smaller screens */
 @media (max-width: 800px) { /* Adjusted breakpoint */
     #main-container {

--- a/main_game.html
+++ b/main_game.html
@@ -56,7 +56,7 @@
             <button id="action-look" class="action-button">Look Around</button>
             <button id="action-inventory" class="action-button">View Inventory</button>
             <button id="action-skills" class="action-button">Skills</button> <!-- Placeholder, as in previous JS -->
-            <button id="action-enter-town" class="action-button" style="display: none;">Enter Town</button>
+            <button id="action-enter-town" class="action-button">Enter Town</button>
             <button id="action-open-town-view" class="action-button">Town View</button>
             <!-- More actions can be added here or dynamically by main_game.js -->
         </div>

--- a/main_game.js
+++ b/main_game.js
@@ -92,6 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (openTownViewButton) {
             const hasTown = Boolean(gameState.current_town_id);
             openTownViewButton.disabled = !hasTown;
+            openTownViewButton.classList.toggle('disabled', !hasTown);
             openTownViewButton.title = hasTown ? '' : 'No town discovered yet.';
         }
         // Add logic for other contextual buttons here if needed
@@ -192,16 +193,9 @@ document.addEventListener('DOMContentLoaded', () => {
             console.warn("No town ID available for town view navigation.");
             return;
         }
-        try {
-            const resp = await fetch('town_view.html', { method: 'HEAD' });
-            if (!resp.ok) throw new Error(`town_view.html unreachable: ${resp.status}`);
-            const url = new URL('town_view.html', window.location.href);
-            url.searchParams.set('town', gameState.current_town_id);
-            window.location.href = url.toString();
-        } catch (err) {
-            console.error('Failed to load town view:', err);
-            addMessage('Error: Town view could not be loaded.');
-        }
+        const url = new URL('town_view.html', window.location.href);
+        url.searchParams.set('town', gameState.current_town_id);
+        window.location.assign(url.toString());
     }
 
     // --- Event Listeners ---
@@ -218,4 +212,5 @@ document.addEventListener('DOMContentLoaded', () => {
     fetchGameState(); // Fetch initial game state when the DOM is ready.
 
     console.log("Main game interface JS initialized. Attempting to fetch initial game state.");
+    window.__mainGame = { handleOpenTownView, updateUI };
 });

--- a/test_app_game_api.py
+++ b/test_app_game_api.py
@@ -38,11 +38,8 @@ class TestGameAPI(unittest.TestCase):
         # unless explicitly designed to. For these sequence-named tests,
         # we'll allow session state to persist across them within a single run.
         # If tests were to be run in isolation, each would need full setup.
-        with self.client:
-            # Clearing session if needed:
-            # with self.client.session_transaction() as sess:
-            # sess.clear()
-            pass
+        with self.client.session_transaction() as sess:
+            sess.clear()
 
 
     def test_01_get_initial_game_state(self):
@@ -58,6 +55,7 @@ class TestGameAPI(unittest.TestCase):
             self.assertIn('messages', data)
             self.assertTrue(len(data['messages']) > 0)
             self.assertIn("Welcome to the adventure!", data['messages'][0])
+            self.assertEqual(data.get('current_town_id'), 'starting_town')
 
 
     def test_02_initialize_with_character(self):
@@ -232,6 +230,16 @@ class TestGameAPI(unittest.TestCase):
             self.assertEqual(data.get('name'), 'testville')
             self.assertEqual(data.get('environment_type'), 'plains')
             self.assertIn('buildings', data)
+
+    def test_09_leave_town_endpoint(self):
+        """Ensure leave_town endpoint clears the current town."""
+        with self.client:
+            self.client.post('/api/game/action', json={"action": "enter town"})
+            resp = self.client.post('/api/game/leave_town')
+            self.assertEqual(resp.status_code, 200)
+            data = json.loads(resp.data.decode('utf-8'))
+            self.assertNotIn('current_town_id', data)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/main_game_navigation.test.js
+++ b/tests/main_game_navigation.test.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+import vm from 'vm';
+
+test('handleOpenTownView builds correct URL', () => {
+  const js = fs.readFileSync(path.join(process.cwd(), 'main_game.js'), 'utf8');
+  const start = js.indexOf('async function handleOpenTownView');
+  const end = js.indexOf('}', js.indexOf('window.location.assign', start)) + 1;
+  const snippet = js.slice(start, end);
+  const code = `let captured; const window={location:{href:'http://host/game', assign:u=>{captured=u}}}; let gameState={current_town_id:'startville'};` + snippet + 'handleOpenTownView(); captured;';
+  const result = vm.runInNewContext(code, { URL });
+  expect(result).toBe('http://host/town_view.html?town=startville');
+});

--- a/town_view.js
+++ b/town_view.js
@@ -117,7 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const params = new URLSearchParams(window.location.search);
-    let effectiveTownId = params.get('town') || 'test_town_id';
+    let effectiveTownId = params.get('town') || sessionStorage.getItem('currentTownId') || 'test_town_id';
     if (!params.get('town')) {
         console.warn(`Town View: No town ID in URL. Using fallback: ${effectiveTownId}.`);
         if (townInfoPanel) {
@@ -140,7 +140,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     if (backButton) {
-        backButton.addEventListener('click', () => {
+        backButton.addEventListener('click', async () => {
+            try {
+                await fetch('/api/game/leave_town', { method: 'POST' });
+            } catch (e) {
+                console.warn('Failed to notify server about leaving town:', e);
+            }
             window.location.href = 'main_game.html';
         });
     }


### PR DESCRIPTION
## Summary
- start the player in a town with the town view unlocked
- make `Enter Town` button visible from HTML and style disabled town view button
- simplify open-town navigation logic and expose helper for tests
- add town view navigation button on the index page
- allow town view to load town ID from session storage and notify backend on exit
- add backend `leave_town` endpoint and support a `leave town` action
- expand API and frontend tests for new behaviour

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684b495bdf60832fb2e25f933f1cfc88