### PR TITLE
Add Vercel integration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ vercel
 
 Make sure to set `GEMINI_API_KEY` in your Vercel project settings so that `/api/gemini.js` can call the Gemini API correctly.
 When running the Flask server locally, the `/api/gemini` route will proxy to the same API if `GEMINI_API_KEY` is set in your environment.
+
+### GitHub Integration
+
+This repository is linked to Vercel via the GitHub app. Every push to `main` automatically deploys a new production build, while pull requests create preview deployments. These development snapshots use the Gemini serverless API for any AI prompts.


### PR DESCRIPTION
## Summary
- document how GitHub pushes deploy to Vercel
- note that preview deployments also use the Gemini API

## Testing
- `pytest -q` *(fails: AttributeError: 'NoneType' object has no attribute 'session_transaction')*
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684b637b729c832f8f2d42893008d877