### PR TITLE
Fix town view environment handling and remove localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,6 @@ When running the Flask server locally, the `/api/gemini` route will proxy to the
 
 ### GitHub Integration
 
-This repository is linked to Vercel via the GitHub app. Every push to `main` automatically deploys a new production build, while pull requests create preview deployments. These development snapshots use the Gemini serverless API for any AI prompts. The GitHub connection means the repo acts as the single source of truth: each push triggers a Vercel build that includes the serverless functions in `api/`. Set `FLASK_BASE` if those functions should proxy to a local Flask server during development.
+This repository is linked to Vercel via the GitHub app. Every push to `main` automatically deploys a new production build, while pull requests create preview deployments. These development snapshots use the Gemini serverless API for any AI prompts. The GitHub connection means the repo acts as the single source of truth: each push triggers a Vercel build that includes the serverless functions in `api/`.
+
+Set the `FLASK_BASE` environment variable to the full URL of your Flask backend. The API functions will fail if this value is not configured.

--- a/api/town/[id].js
+++ b/api/town/[id].js
@@ -1,10 +1,19 @@
 export default async function handler(req, res) {
   const { id } = req.query;
   const env = req.query.env || 'forest';
-  const base = process.env.FLASK_BASE || 'http://localhost:5001';
+  const base = process.env.FLASK_BASE;
+  if (!base) {
+    console.error('FLASK_BASE not set');
+    return res.status(500).json({ error: 'FLASK_BASE not configured' });
+  }
   const url = `${base}/api/town/${id}/map?env=${env}`;
   try {
     const resp = await fetch(url);
+    if (!resp.ok) {
+      const text = await resp.text();
+      console.error('Town fetch failed:', resp.status, text);
+      return res.status(resp.status).json({ error: `Backend ${resp.status}` });
+    }
     const data = await resp.json();
     return res.status(resp.status).json(data);
   } catch (e) {

--- a/app.py
+++ b/app.py
@@ -3,8 +3,7 @@ from flask_cors import CORS
 import os
 import requests
 from dataclasses import asdict, is_dataclass
-from math import floor # Added for HP calculation
-from math import floor # Added for HP calculation
+from math import floor  # Added for HP calculation
 
 # Attempt to import DataManagementModule and RulesEngine
 try:

--- a/character_creator.js
+++ b/character_creator.js
@@ -195,7 +195,7 @@ const LOCAL_CLASSES = [
     }
 ];
 
-const API_BASE_URL = "http://localhost:5001/api";
+const API_BASE_URL = window.location.origin + '/api';
 let allFeatsData = []; // To store all feats fetched once
 
 // --- Ability Score Constants (Point Buy) ---

--- a/main_game.js
+++ b/main_game.js
@@ -106,8 +106,9 @@ document.addEventListener('DOMContentLoaded', () => {
             sessionStorage.setItem('currentTownId', gameState.current_town_id);
 
             // Short delay to allow the message to be rendered, then redirect.
+            const env = gameState.current_environment || sessionStorage.getItem('currentEnvironment');
             setTimeout(() => {
-                window.location.href = 'town_view.html';
+                openTownView(gameState.current_town_id, env);
             }, 500); // 0.5 second delay
             // The trigger_town_navigation flag was part of the transient response from backend.
             // No client-side reset of the flag is needed as the page will reload/navigate away.

--- a/town_view.js
+++ b/town_view.js
@@ -74,11 +74,16 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log("Rendering town:", townData.name);
 
         if (townMapContainer) {
-            ['forest','plains','mountain'].forEach(env => townMapContainer.classList.remove(`town-border-${env}`));
+            townMapContainer.classList.forEach(cls => {
+                if (cls.startsWith('town-border-')) townMapContainer.classList.remove(cls);
+            });
             townMapContainer.classList.add(`town-border-${townData.environment_type}`);
 
-            townMapContainer.innerHTML = `<h2>Welcome to ${townData.name} (${townData.environment_type})</h2>`;
-            if(townData.description) {
+            townMapContainer.innerHTML = '';
+            const h2 = document.createElement('h2');
+            h2.textContent = `Welcome to ${townData.name} (${townData.environment_type})`;
+            townMapContainer.appendChild(h2);
+            if (townData.description) {
                 const descP = document.createElement('p');
                 descP.textContent = townData.description;
                 townMapContainer.appendChild(descP);
@@ -93,7 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
             townMapContainer.appendChild(buildingList);
         }
         if (townInfoPanel) {
-            townInfoPanel.innerHTML = `<p>Details about ${townData.name} will appear here.</p>`;
+            townInfoPanel.textContent = `Details about ${townData.name} will appear here.`;
         }
     }
 
@@ -101,10 +106,19 @@ document.addEventListener('DOMContentLoaded', () => {
      * Placeholder for handling building clicks.
      * @param {object} building - The building object that was clicked.
      */
-    function handleBuildingClick(building) {
-        console.log("Clicked on building:", building.name);
-        if (townInfoPanel) {
-            townInfoPanel.innerHTML = `<h3>${building.name}</h3><p>Type: ${building.type}</p><p>Position: X:${building.position.x}, Y:${building.position.y}</p>`;
+   function handleBuildingClick(building) {
+       console.log("Clicked on building:", building.name);
+       if (townInfoPanel) {
+            townInfoPanel.innerHTML = '';
+            const h3 = document.createElement('h3');
+            h3.textContent = building.name;
+            const typeP = document.createElement('p');
+            typeP.textContent = `Type: ${building.type}`;
+            const posP = document.createElement('p');
+            posP.textContent = `Position: X:${building.position.x}, Y:${building.position.y}`;
+            townInfoPanel.appendChild(h3);
+            townInfoPanel.appendChild(typeP);
+            townInfoPanel.appendChild(posP);
         }
     }
 
@@ -136,10 +150,20 @@ document.addEventListener('DOMContentLoaded', () => {
             try {
                 const resp = await fetch(`${API_BASE}/game/leave_town`, { method: 'POST' });
                 if (!resp.ok) {
-                    console.warn('leave_town request failed', resp.status);
+                    console.error('leave_town request failed', resp.status);
+                    if (errorPanel) {
+                        errorPanel.textContent = 'Failed to leave town.';
+                        errorPanel.style.color = 'red';
+                    }
+                    return;
                 }
             } catch (e) {
-                console.warn('Failed to notify server about leaving town:', e);
+                console.error('Failed to notify server about leaving town:', e);
+                if (errorPanel) {
+                    errorPanel.textContent = 'Error contacting server.';
+                    errorPanel.style.color = 'red';
+                }
+                return;
             }
             window.location.href = 'main_game.html';
         });


### PR DESCRIPTION
## Summary
- require `FLASK_BASE` and handle errors in town API
- document that `FLASK_BASE` must be set
- use relative API base in character creator
- redirect to town view with the current environment
- sanitize DOM writes and improve error handling in town view
- drop duplicate math import

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684bd116dc48832f86a0f9d9fb2d10e8